### PR TITLE
Fix undefined variable on new static pages.

### DIFF
--- a/app/views/admin/page/index.blade.php
+++ b/app/views/admin/page/index.blade.php
@@ -5,6 +5,7 @@
     <div class="row">
       <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
         <h1 class="page-header">All Static Pages</h1>
+        {{ link_to_route('admin.page.create', 'Create new page »', null, array('class' => 'btn btn-default', 'role'=> 'button')) }}
         <div class="table-responsive">
           <table class="table table-striped">
             <thead>

--- a/app/views/admin/page/partials/_form_page.blade.php
+++ b/app/views/admin/page/partials/_form_page.blade.php
@@ -23,7 +23,7 @@
 
   {{-- Block item grouping --}}
   <div class="well">
-    @if (count($blocks) > 0)
+    @if (isset($blocks) && count($blocks) > 0)
       @foreach ($blocks as $key=>$block)
 
         <div class="repeatable">


### PR DESCRIPTION
`blocks` was not defined on a new page. :facepunch: 
