### PR TITLE
Adding symlink step to cap deploy to link settings file from shared

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,3 +14,15 @@ set :scm, :none
 set :deploy_via, :copy
 
 ssh_options[:keys] = [ENV["CAP_PRIVATE_KEY"]]
+
+namespace :deploy do
+
+  task :link_settings do
+    on roles(:app) do |host|
+      execute "ln -nfs #{shared_path}/shared/.env.php #{release_path}/"
+    end
+  end
+
+  after :symlink, 'deploy:link_settings'
+
+end


### PR DESCRIPTION
The deployment needs an additional step to symlink the application settings file to the appropriate place.

@angaither 
