### PR TITLE
Adding capacity to use MarkdownExtra in page description field. Will exp...

### DIFF
--- a/app/controllers/PageController.php
+++ b/app/controllers/PageController.php
@@ -1,5 +1,7 @@
 <?php
 
+use Michelf\MarkdownExtra;
+
 class PageController extends \BaseController {
 
   /**
@@ -46,6 +48,7 @@ class PageController extends \BaseController {
     }
     $page->title = $input['title'];
     $page->description = $input['description'];
+    $page->description_html = MarkdownExtra::defaultTransform($input['description']);
 
     // Save the page fields
     $page->save();
@@ -115,11 +118,13 @@ class PageController extends \BaseController {
    */
   public function update($id)
   {
-    $input = Input::except("blocks");
+    $input = Input::except('blocks');
     $page = Page::whereId($id)->firstOrFail();
     $path = Path::wherePageId($id)->firstOrFail();
 
+    $input['description_html'] = MarkdownExtra::defaultTransform($input['description']);
     $page->fill($input)->save();
+
     $path->link_text = $input['link_text'];
     $path->save();
 

--- a/app/models/Page.php
+++ b/app/models/Page.php
@@ -2,7 +2,7 @@
 
 class Page extends \Eloquent {
 
-  protected $fillable = ['title', 'url', 'description', 'image'];
+  protected $fillable = ['title', 'url', 'description', 'description_html', 'image'];
 
   public function path()
   {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "require": {
     "laravel/framework": "4.2.*",
     "laracasts/validation": "~1.0",
-    "guzzlehttp/guzzle": "4.*"
+    "guzzlehttp/guzzle": "4.*",
+    "michelf/php-markdown": "1.4.*"
   },
   "require-dev": {
     "way/generators": "~2.0"


### PR DESCRIPTION
...and to other fields in Admin.

The composer package used allows for [MarkdownExtra](https://michelf.ca/projects/php-markdown/extra/), which enhances what you can already do with Markdown, such as adding ids/classes to headers, definition lists and more! 

This PR only adds Markdown to the description text in static pages. Next steps include:
- add Markdown to static page blocks
- review what other fields might need markdown syntax

Since a new package has been included to composer, make sure to run `composer update`!

@angaither 

CC: @barryclark @DFurnes 

Refs #87
