### PR TITLE
Limiting the number of releases capistrano keeps

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,3 +27,5 @@ namespace :deploy do
   after :symlink, 'deploy:link_settings'
 
 end
+
+after "deploy:update", "deploy:cleanup"


### PR DESCRIPTION
Keeping too many releases on the host box takes up too much disk space eventually causing an out of disk space error on deploy.  Limiting releases to 1.  Any past releases can always be redeployed through Wercker.

@angaither 
