### PR TITLE
Using new version of build box with php-curl

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: blisteringherb/scholarship@0.0.5
+box: blisteringherb/scholarship@0.0.6
 build:
     # The steps that will be executed on build
     steps:


### PR DESCRIPTION
The application builds are failing in part because php-curl isn't installed on the build box.  Bumping the version of the build box to one that includes php-curl.
