### PR TITLE
Artisan migrate

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,8 +23,7 @@ namespace :deploy do
   end
 
   task :artisan_migrate do
-    run "cd #{release_path}"
-    run "php artisan migrate --force"
+    run "cd #{release_path} && php artisan migrate --force"
   end
 
 end


### PR DESCRIPTION
Running the `php artisan migrate --force` command after cap symlinks the settings file.  This will run on every deployment

@angaither 
