### PR TITLE
Fixes #242: Sets Redis as default queue

### DIFF
--- a/app/config/queue.php
+++ b/app/config/queue.php
@@ -1,85 +1,14 @@
 <?php
 
-return array(
+return [
 
-  /*
-  |--------------------------------------------------------------------------
-  | Default Queue Driver
-  |--------------------------------------------------------------------------
-  |
-  | The Laravel queue API supports a variety of back-ends via an unified
-  | API, giving you convenient access to each back-end using the same
-  | syntax for each one. Here you may set the default queue driver.
-  |
-  | Supported: "sync", "beanstalkd", "sqs", "iron", "redis"
-  |
-  */
+    'default'     => 'redis',
 
-  'default' => 'sync',
+    'connections' => [
 
-  /*
-  |--------------------------------------------------------------------------
-  | Queue Connections
-  |--------------------------------------------------------------------------
-  |
-  | Here you may configure the connection information for each server that
-  | is used by your application. A default configuration has been added
-  | for each back-end shipped with Laravel. You are free to add more.
-  |
-  */
-
-  'connections' => array(
-
-    'sync' => array(
-      'driver' => 'sync',
-    ),
-
-    'beanstalkd' => array(
-      'driver' => 'beanstalkd',
-      'host'   => 'localhost',
-      'queue'  => 'default',
-      'ttr'    => 60,
-    ),
-
-    'sqs' => array(
-      'driver' => 'sqs',
-      'key'    => 'your-public-key',
-      'secret' => 'your-secret-key',
-      'queue'  => 'your-queue-url',
-      'region' => 'us-east-1',
-    ),
-
-    'iron' => array(
-      'driver'  => 'iron',
-      'host'    => 'mq-aws-us-east-1.iron.io',
-      'token'   => 'your-token',
-      'project' => 'your-project-id',
-      'queue'   => 'your-queue-name',
-      'encrypt' => true,
-    ),
-
-    'redis' => array(
-      'driver' => 'redis',
-      'queue'  => 'default',
-    ),
-
-  ),
-
-  /*
-  |--------------------------------------------------------------------------
-  | Failed Queue Jobs
-  |--------------------------------------------------------------------------
-  |
-  | These options configure the behavior of failed queue job logging so you
-  | can control which database and table are used to store the jobs that
-  | have failed. You may change them to any database / table you wish.
-  |
-  */
-
-  'failed' => array(
-
-    'database' => 'mysql', 'table' => 'failed_jobs',
-
-  ),
-
-);
+        'redis' => array(
+          'driver' => 'redis',
+          'queue'  => getenv('REDIS_QUEUE'),
+        ),
+    ],
+];

--- a/default.env.local.php
+++ b/default.env.local.php
@@ -6,4 +6,7 @@ return [
   'DB_USERNAME' => 'username',
   'DB_PASSWORD' => 'password',
   'DB_NAME' => 'db_name'
+
+  'REDIS_QUEUE' => 'default',
+
    ];


### PR DESCRIPTION
#183 wants a queue handler in place. This sets Redis as the default.

Note the new required setting in `.env.php` / `.env.local.php`:

`'REDIS_QUEUE' => 'default',`

/cc @blisteringherb Need to install vanilla Redis in production.
