### PR TITLE
Send emails off from the queue.

### DIFF
--- a/app/models/Email.php
+++ b/app/models/Email.php
@@ -42,7 +42,7 @@ class Email extends Eloquent {
       );
 
     // Send off the message.
-    Mail::send('emails.email', $email_data, function($message) use ($email_data)
+    Mail::queue('emails.email', $email_data, function($message) use ($email_data)
     {
       $message->to($email_data['to'])->subject($email_data['subject']);
     });


### PR DESCRIPTION
Fixes #183 

Note, locally you will need to run `php artisan queue:listen` to actually get emails, otherwise things will sit in the queue forever.

@blisteringherb has set this up in production to run as a daemon queue worker. 
