### PR TITLE
Will throw property of non-object error if not set.

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -122,7 +122,7 @@ Route::filter('role', function($route, $request, $role)
 Route::filter('startedProcess', function($route, $request, $value)
 {
   $user = Auth::user();
-  if ($user->$value)
+  if (!is_null($user->$value))
   {
     return Redirect::route($value .'.edit', $user->id);
   }


### PR DESCRIPTION
Fixes errors specialist guild was seeing.

@mikefantini this should fix the errors in the [trello](https://trello.com/c/QJCp6tYz/116-on-ios8-5s-creating-profile-throws-an-exception) card. It doesn't make sense that it was only showing up on iOS-8 though...
