### PR TITLE
Adding the failed_jobs table to queue config

### DIFF
--- a/app/config/queue.php
+++ b/app/config/queue.php
@@ -11,4 +11,10 @@ return [
           'queue'  => getenv('REDIS_QUEUE'),
         ),
     ],
+
+    'failed' => array(
+
+      'database' => 'mysql', 'table' => 'failed_jobs',
+
+    ),
 ];


### PR DESCRIPTION
The failed_jobs table has been created, but the app/config/queue.php file needs to be updated to tell Laravel to use that tabled to log failed jobs.

@angaither 
