### PR TITLE
Need to run the backup after code is updated

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,7 +42,7 @@ namespace :deploy do
 
 end
 
-before "deploy:update", "deploy:backup_db"
 after "deploy:update", "deploy:cleanup"
 after "deploy:symlink", "deploy:link_folders"
+before "deploy:artisan_migrate", "deploy:backup_db"
 after "deploy:link_folders", "deploy:artisan_migrate", "deploy:artisan_custom_styles"


### PR DESCRIPTION
The current capistrano deployment is failing because the code needs to be updated first before it has access to run the database backup command.

@angaither 
