### PR TITLE
Killing the queue worker after deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,9 +40,13 @@ namespace :deploy do
     run "cd #{release_path} && php artisan custom-styles"
   end
 
+  task :restart_queue_worker do
+    run "ps -ef | grep 'queue:work' | awk '{print $2}' | xargs sudo kill -9"
+  end
+
 end
 
 after "deploy:update", "deploy:cleanup"
 after "deploy:symlink", "deploy:link_folders"
 before "deploy:artisan_migrate", "deploy:backup_db"
-after "deploy:link_folders", "deploy:artisan_migrate", "deploy:artisan_custom_styles"
+after "deploy:link_folders", "deploy:restart_queue_worker", "deploy:artisan_migrate", "deploy:artisan_custom_styles"


### PR DESCRIPTION
- The queue worker script points to the symlinked folder 'current'
  which doesn't automatically get updated when the symlink changes.
  This will restart the worker after the deployment so that the
  correct path to the symlinked folder is referenced by the queue
  worker script. Supervisord will take care of restarting the process
  automatically.

Fixes #482

@angaither 
@mshmsh5000 
