### PR TITLE
Updating to use bower for bootstrap and some fixes.

### DIFF
--- a/app/views/admin/layouts/master.blade.php
+++ b/app/views/admin/layouts/master.blade.php
@@ -8,7 +8,7 @@
 
     <title>Scholarship Application Administration</title>
     <link rel="icon" type="image/ico" href="/favicon.ico?v1"/>
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/dist/bower_components/bootstrap/dist/css/bootstrap.min.css">
     <script src="/dist/bower_components/jquery/dist/jquery.min.js"></script>
     @section('styles')
       <link rel="stylesheet" href="/dist/css/admin.css"/>
@@ -29,6 +29,6 @@
 
     @yield('main_content')
 
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+    <script src="/dist/bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/app/views/admin/settings/emails/edit.blade.php
+++ b/app/views/admin/settings/emails/edit.blade.php
@@ -5,50 +5,45 @@
     <div class="row">
 
       @include('admin.layouts.partials.subnav-settings')
-      {{ Form::open(['route' => 'emails.update']) }}
-
 
       <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
-        <h1 class="page-header">Emails!</h1>
 
+        {{ Form::open(['route' => 'emails.update']) }}
 
-      <div class="panel-group" id="accordion">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h4 class="panel-title">
-                  Applicant Emails
-              </h4>
-            </div>
-              <div class="panel-body">
-                  @foreach($applicant_emails as $key => $email)
+          <h1 class="page-header">Emails!</h1>
 
-                  @include('admin.settings.emails.partials._form_emails',  array('class' => 'applicant'))
-
-                  @endforeach
-
+          <div class="panel-group" id="accordion">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4 class="panel-title">Applicant Emails</h4>
               </div>
+              <div class="panel-body">
+                @foreach($applicant_emails as $key => $email)
+                  @include('admin.settings.emails.partials._form_emails',  array('class' => 'applicant'))
+                @endforeach
+              </div>
+            </div>
           </div>
 
-    <div class="panel-group" id="accordion">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h4 class="panel-title">
-                  Recommender Emails
-              </h4>
-            </div>
-              <div class="panel-body">
-
-                  @foreach($recommender_emails as $key => $email)
-                     @include('admin.settings.emails.partials._form_emails', array('class' => 'recommender'))
-                  @endforeach
-
+          <div class="panel-group" id="accordion">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4 class="panel-title">Recommender Emails</h4>
               </div>
+              <div class="panel-body">
+                @foreach($recommender_emails as $key => $email)
+                   @include('admin.settings.emails.partials._form_emails', array('class' => 'recommender'))
+                @endforeach
+              </div>
+            </div>
+          </div>
+
+          <div>
+            {{ Form::submit('Update Email Settings', ['class' => 'btn btn-default']) }}
           </div>
 
         {{ Form::close() }}
-         <div>
-            {{ Form::submit('Update Email Settings', ['class' => 'btn btn-default']) }}
-          </div>
+
       </div>
 
     </div>

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "tests"
   ],
   "dependencies": {
+    "bootstrap": "~3.3.0",
     "jquery": "~2.1.1",
     "picturefill": "~2.1.0",
     "normalize.css": "~3.0.1",


### PR DESCRIPTION
Resolves #32

Decided to use Bower for loading Bootstrap CSS/JS for admin. Didn't make sense to get files from the BootstrapCDN since it's really used only for the admin area and this way it loads fine and admin is usable if working locally and with no internets.

Also did a fix for the Email settings page which was missing some closing `</div>`s and thus the page was breaking visually.

@angaither 

CC: @barryclark @DFurnes 
