### PR TITLE
Fixes #579: Increases session length from two hours to one week.

### DIFF
--- a/app/config/session.php
+++ b/app/config/session.php
@@ -29,7 +29,7 @@ return array(
   |
   */
 
-  'lifetime' => 120,
+  'lifetime' => 10080, // 10080 minutes = 1 week. Default: 120 (2 hours)
 
   'expire_on_close' => false,
 


### PR DESCRIPTION
This is a huge increase in session length, but I'm not worried at these traffic levels. Increasing session length to this long should eliminate the chance that an applicant will time out in between saves.
