### PR TITLE
Update to fix save as draft profile bug.

### DIFF
--- a/app/models/Application.php
+++ b/app/models/Application.php
@@ -50,8 +50,13 @@ class Application extends Eloquent {
   // Given a user id, returns bool if all required fields are
   public static function isSubmitted($user_id)
   {
-    $application = Application::where('user_id', $user_id)->select('submitted')->firstOrFail();
-    return $application->submitted;
+    $application = Application::where('user_id', $user_id)->select('submitted')->first();
+
+    if ($application) {
+      return $application->submitted;
+    }
+
+    return false;
   }
 
   // Given an application id returns if app is submitted & complete


### PR DESCRIPTION
Resolves #579

@angaither 

@mshmsh5000 thanks for the detailed steps! I was able to recreate the bug exactly as specified!

So it also turns out that we were using a method on the Application query, where if nothing returned (or was found) then the query is supposed to fail purposefully (`->firstOrFail()`), so we can intercept it and handle the error. However, where it was occurring on the app in this specific case was breaking things in this unique scenario where an applicant happened to start the profile and only save it as draft to come back to later. I did a change to return `FALSE` from that function, so the **Profile controller** doesn't completely break and can continue on its way.

I tested the same steps after this fix and it worked fine. Feel free to merge this in if all looks good. This should fix it, but best to double check and test it on the staged version!

CC:/ @mshmsh5000 @lizzydivine @barryclark 
