### PR TITLE
Enabling new artisan command, and adding some error handling.

### DIFF
--- a/app/commands/TransferWinnersCommand.php
+++ b/app/commands/TransferWinnersCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class TransferWinnersCommand extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'transfer:winners';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Collect winners data and transfer to winners table.';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function fire()
+	{
+    try {
+      $transfer = Winner::transferWinners();
+      $this->info('Transfer completed, have a scholarly beer!');
+    }
+    catch (Exception $error) {
+      $this->error($error->getMessage());
+    }
+	}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	// /**
+	//  * Get the console command arguments.
+	//  *
+	//  * @return array
+	//  */
+	// protected function getArguments()
+	// {
+	// 	return array(
+	// 		array('example', InputArgument::REQUIRED, 'An example argument.'),
+	// 	);
+	// }
+
+	// /**
+	//  * Get the console command options.
+	//  *
+	//  * @return array
+	//  */
+	// protected function getOptions()
+	// {
+	// 	return array(
+	// 		array('example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null),
+	// 	);
+	// }
+
+}

--- a/app/commands/TransferWinnersCommand.php
+++ b/app/commands/TransferWinnersCommand.php
@@ -38,7 +38,23 @@ class TransferWinnersCommand extends Command {
   public function fire()
   {
     try {
-      $transfer = (new Winner)->transferWinners();
+      $users = (new Winner)->collectBiosForWinners();
+
+      foreach ($users as $user) {
+        $winner = Winner::where('user_id', $user->id)->firstOrFail();
+
+        $winner->setUserData($user);
+
+        $winner->save();
+      }
+
+      // Clear cache since scholarship winner's information was updated.
+      $scholarship_ids = Scholarship::lists('id');
+      array_unshift($scholarship_ids, 0);
+
+      foreach ($scholarship_ids as $id) {
+        Event::fire('data.update', ['winners', $id]);
+      }
 
       $this->info('Transfer completed, have a scholarly beer!');
     }
@@ -46,47 +62,4 @@ class TransferWinnersCommand extends Command {
       $this->error($error->getMessage());
     }
   }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  // /**
-  //  * Get the console command arguments.
-  //  *
-  //  * @return array
-  //  */
-  // protected function getArguments()
-  // {
-  //  return array(
-  //    array('example', InputArgument::REQUIRED, 'An example argument.'),
-  //  );
-  // }
-
-  // /**
-  //  * Get the console command options.
-  //  *
-  //  * @return array
-  //  */
-  // protected function getOptions()
-  // {
-  //  return array(
-  //    array('example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null),
-  //  );
-  // }
-
 }

--- a/app/commands/TransferWinnersCommand.php
+++ b/app/commands/TransferWinnersCommand.php
@@ -6,45 +6,46 @@ use Symfony\Component\Console\Input\InputArgument;
 
 class TransferWinnersCommand extends Command {
 
-	/**
-	 * The console command name.
-	 *
-	 * @var string
-	 */
-	protected $name = 'transfer:winners';
+  /**
+   * The console command name.
+   *
+   * @var string
+   */
+  protected $name = 'transfer:winners';
 
-	/**
-	 * The console command description.
-	 *
-	 * @var string
-	 */
-	protected $description = 'Collect winners data and transfer to winners table.';
+  /**
+   * The console command description.
+   *
+   * @var string
+   */
+  protected $description = 'Collect winners data and transfer to winners table.';
 
-	/**
-	 * Create a new command instance.
-	 *
-	 * @return void
-	 */
-	public function __construct()
-	{
-		parent::__construct();
-	}
+  /**
+   * Create a new command instance.
+   *
+   * @return void
+   */
+  public function __construct()
+  {
+    parent::__construct();
+  }
 
-	/**
-	 * Execute the console command.
-	 *
-	 * @return mixed
-	 */
-	public function fire()
-	{
+  /**
+   * Execute the console command.
+   *
+   * @return mixed
+   */
+  public function fire()
+  {
     try {
-      $transfer = Winner::transferWinners();
+      $transfer = (new Winner)->transferWinners();
+
       $this->info('Transfer completed, have a scholarly beer!');
     }
     catch (Exception $error) {
       $this->error($error->getMessage());
     }
-	}
+  }
 
 
 
@@ -62,28 +63,30 @@ class TransferWinnersCommand extends Command {
 
 
 
-	// /**
-	//  * Get the console command arguments.
-	//  *
-	//  * @return array
-	//  */
-	// protected function getArguments()
-	// {
-	// 	return array(
-	// 		array('example', InputArgument::REQUIRED, 'An example argument.'),
-	// 	);
-	// }
 
-	// /**
-	//  * Get the console command options.
-	//  *
-	//  * @return array
-	//  */
-	// protected function getOptions()
-	// {
-	// 	return array(
-	// 		array('example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null),
-	// 	);
-	// }
+
+  // /**
+  //  * Get the console command arguments.
+  //  *
+  //  * @return array
+  //  */
+  // protected function getArguments()
+  // {
+  //  return array(
+  //    array('example', InputArgument::REQUIRED, 'An example argument.'),
+  //  );
+  // }
+
+  // /**
+  //  * Get the console command options.
+  //  *
+  //  * @return array
+  //  */
+  // protected function getOptions()
+  // {
+  //  return array(
+  //    array('example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null),
+  //  );
+  // }
 
 }

--- a/app/controllers/WinnerController.php
+++ b/app/controllers/WinnerController.php
@@ -21,19 +21,33 @@ class WinnerController extends \BaseController {
     return View::make('admin.winners.index', compact('winners', 'scholarships'));
   }
 
-
+  /**
+   * Store a single winnner record.
+   * 
+   * @return Response
+   */
   public function store()
   {
-    $scholarship_id = Scholarship::getCurrentScholarship()->pluck('id');
-
     $user_id = Input::get('user_id');
+
+    $user = (new User)->getFullBios($user_id);
+
     $winner = new Winner;
     $winner->user_id = $user_id;
-    $winner->scholarship_id = $scholarship_id;
+    $winner->scholarship_id = $user->application['scholarship_id'];
+    $winner->first_name = $user->first_name;
+    $winner->last_name = $user->last_name;
+    $winner->city = $user->profile['city'];
+    $winner->state = $user->profile['state'];
+    $winner->gpa = $user->application['gpa'];
+    $winner->participation = $user->application['participation'];
 
     $winner->save();
+    
 
-    return Redirect::back()->with('flash_message', ['text' => '<strong>Success:</strong> Awesome, we got that person as a winner for you!', 'class' => 'alert-success']);
+    dd($winner->toArray());
+    
+    // return Redirect::back()->with('flash_message', ['text' => '<strong>Success:</strong> Awesome, we got that person as a winner for you!', 'class' => 'alert-success']);
   }
 
 

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -127,4 +127,29 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
   {
     return $user = User::whereId($id)->select('first_name', 'last_name', 'email')->first()->toArray();
   }
+
+
+  /**
+   * Get full public biography for user.
+   * 
+   * @param  int|array $ids  Single or multiple user ids.
+   * @return object
+   */
+  public function getFullBios($ids)
+  {
+    $fields = [
+      'profile' => function ($query) { $query->select('user_id', 'city', 'state'); },
+      'application' => function ($query) { $query->select('user_id', 'scholarship_id', 'gpa', 'participation'); },
+    ];
+
+    if (is_array($ids)) {
+      $data = User::with($fields)->whereIn('id', $ids)->get()->toArray();
+    }
+    else {
+      $data = User::with($fields)->findOrFail($ids);
+    }
+
+    return $data;
+  }
+
 }

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -143,7 +143,7 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
     ];
 
     if (is_array($ids)) {
-      $data = User::with($fields)->whereIn('id', $ids)->get()->toArray();
+      $data = User::with($fields)->whereIn('id', $ids)->get();
     }
     else {
       $data = User::with($fields)->findOrFail($ids);

--- a/app/models/Winner.php
+++ b/app/models/Winner.php
@@ -1,6 +1,7 @@
 <?php
 
 class Winner extends Eloquent {
+
   protected $guarded = ['id'];
 
   public $timestamps = false;
@@ -66,6 +67,33 @@ class Winner extends Eloquent {
     else {
       return $cachedWinners;
     }
+  }
+
+
+  /**
+   * Transfer collected winner data into winners table.
+   * 
+   * @param  object $applicant Single applicant's data.
+   * @throws Exception If the database migration has not been run, then missing required columns.
+   * @return boolean
+   */
+  public static function transferWinners($applicant = null) {
+    // @PseudoCode steps:
+    // 
+    // Confirm database structure.
+    // If parameter passed then only adding single row.
+    // If no parameter, then collecting all winner data and updating the table.
+    // 
+    // Collect winner's data.
+    // Update the winner's table with the data.
+    // Exit and party.
+
+    if (! Schema::hasColumn('winners', 'first_name_ds')) {
+      throw new Exception('Please run migration command to add new fields to the winners table in database.');
+    }
+
+
+    return true;
   }
 
 }

--- a/app/models/Winner.php
+++ b/app/models/Winner.php
@@ -19,6 +19,7 @@ class Winner extends Eloquent {
   }
 
 
+
   /**
    * Retrieve winners data for the specified scholarship.
    *
@@ -73,26 +74,26 @@ class Winner extends Eloquent {
   /**
    * Transfer collected winner data into winners table.
    * 
-   * @param  object $applicant Single applicant's data.
    * @throws Exception If the database migration has not been run, then missing required columns.
    * @return boolean
    */
-  public static function transferWinners($applicant = null) {
+  public function transferWinners() {
     // @PseudoCode steps:
     // 
     // Confirm database structure.
-    // If parameter passed then only adding single row.
-    // If no parameter, then collecting all winner data and updating the table.
-    // 
-    // Collect winner's data.
+    // Collect all winner data.
     // Update the winner's table with the data.
     // Exit and party.
 
-    if (! Schema::hasColumn('winners', 'first_name_ds')) {
+    if (! Schema::hasColumn('winners', 'first_name')) {
       throw new Exception('Please run migration command to add new fields to the winners table in database.');
     }
 
+    
+    $scholarships = Scholarship::lists('id');
+    array_unshift($scholarships, 0);
 
+    // Still in progress... Need to lay some foundation in User model.
     return true;
   }
 

--- a/app/routes.php
+++ b/app/routes.php
@@ -85,16 +85,6 @@ Route::group(['before' => 'role:administrator', 'prefix' => 'admin'], function()
 });
 
 
-// @Delet: Demo testing purposes.
-Route::get('/transfer', function() {
-  // dd(Winner::transferWinners());
-
-  $winner = new Winner;
-
-  dd($winner->transferWinners());
-});
-
-
 # Pages
 // This route needs to be the last route in the list that is hit
 // because the wildcard catches anything after the root and routes

--- a/app/routes.php
+++ b/app/routes.php
@@ -85,6 +85,11 @@ Route::group(['before' => 'role:administrator', 'prefix' => 'admin'], function()
 });
 
 
+// @Delet: Demo testing purposes.
+Route::get('/transfer', function() {
+  dd(Winner::transferWinners());
+});
+
 
 # Pages
 // This route needs to be the last route in the list that is hit

--- a/app/routes.php
+++ b/app/routes.php
@@ -87,7 +87,11 @@ Route::group(['before' => 'role:administrator', 'prefix' => 'admin'], function()
 
 // @Delet: Demo testing purposes.
 Route::get('/transfer', function() {
-  dd(Winner::transferWinners());
+  // dd(Winner::transferWinners());
+
+  $winner = new Winner;
+
+  dd($winner->transferWinners());
 });
 
 

--- a/app/start/artisan.php
+++ b/app/start/artisan.php
@@ -12,3 +12,5 @@
 */
 
 Artisan::add(new CustomStylesCommand);
+
+Artisan::add(new TransferWinnersCommand);


### PR DESCRIPTION
### Fixes #669

This PR adds a new artisan command called `transfer:winners`, which calls a new method on the `Winner` model (along with a few other methods) to transfer the winner data into the `winners` table. It handles mass updating (for data that previously wasn't added) and adding/removing new single rows of students to the `winners` table to add them as they're awarded/revoked a scholarship.

The method on the `Winner` model also does a quick check to confirm that the database has been updated via the migration, otherwise it will throw an error and stops execution.

When doing a full transfer to add all current winner data to the `Winners` table, the transfer command also ensures that the cache of winners for each scholarship is properly cleared, so it can update.


---
@angaither @sbsmith86 