### PR TITLE
Clear Cache Button

### DIFF
--- a/app/Scholarship/Repositories/SettingRepository.php
+++ b/app/Scholarship/Repositories/SettingRepository.php
@@ -118,4 +118,16 @@ class SettingRepository {
       $setting->save();
     });
   }
+
+  /**
+   * Reset the appearance settings.
+   *
+   * @return  void
+   */
+  public function resetAppearanceSettings()
+  {
+    $settings_data = $this->getCategorySettingsVars('appearance');
+
+    createCustomStylesheet($settings_data);
+  }
 }

--- a/app/assets/sass/_admin/_custom.scss
+++ b/app/assets/sass/_admin/_custom.scss
@@ -27,6 +27,19 @@ textarea {
   .btn { width: 100%; }
 
   .btn + .btn { margin-top: 15px; }
+
+  .btn.-hover-red {
+    &:hover {
+      background-color: $app_red;
+      color: #FFF;
+    }
+  }
+
+  form {
+    position: absolute;
+    bottom: 20px;
+    width: 80%;
+  }
 }
 
 .segment + .segment { margin-top: 20px; }

--- a/app/commands/CustomStylesCommand.php
+++ b/app/commands/CustomStylesCommand.php
@@ -41,9 +41,7 @@ class CustomStylesCommand extends Command {
   {
     $settings = new SettingRepository();
 
-    $setting_data = $settings->getCategorySettingsVars('appearance');
-
-    createCustomStylesheet($setting_data);
+    $settings->resetAppearanceSettings();
 
     $this->info('Custom settings have been saved to the cache.');
   }

--- a/app/controllers/admin/SettingsController.php
+++ b/app/controllers/admin/SettingsController.php
@@ -199,9 +199,20 @@ class SettingsController extends \BaseController {
     return Redirect::route('meta-data.edit')->with('flash_message', ['text' => '<strong>Success:</strong> <em>Meta Data</em> settings have been saved!', 'class' => 'alert-success']);
   }
 
+  /**
+   * Clear entire cache.
+   *
+   * @return Response
+   */
   public function clearCache()
   {
-    dd('clear cache');
+    Cache::flush();
+
+    // Reset appearance settings after cache clear.
+    $settings = new SettingRepository();
+    $settings->resetAppearanceSettings();
+
+    return Redirect::back()->with('flash_message', ['text' => '<strong>Success:</strong> Cache has been cleared!', 'class' => 'alert-success']);
   }
 
 }

--- a/app/controllers/admin/SettingsController.php
+++ b/app/controllers/admin/SettingsController.php
@@ -199,4 +199,9 @@ class SettingsController extends \BaseController {
     return Redirect::route('meta-data.edit')->with('flash_message', ['text' => '<strong>Success:</strong> <em>Meta Data</em> settings have been saved!', 'class' => 'alert-success']);
   }
 
+  public function clearCache()
+  {
+    dd('clear cache');
+  }
+
 }

--- a/app/routes.php
+++ b/app/routes.php
@@ -77,6 +77,7 @@ Route::group(['before' => 'role:administrator', 'prefix' => 'admin'], function()
   Route::post('settings/appearance', ['as' => 'appearance.update', 'uses' => 'SettingsController@updateAppearance']);
   Route::get('settings/meta-data', ['as' => 'meta-data.edit', 'uses' => 'SettingsController@editMetaData']);
   Route::post('settings/meta-data', ['as' => 'meta-data.update', 'uses' => 'SettingsController@updateMetaData']);
+  Route::post('settings/clear-cache', ['as' => 'general.clear-cache', 'uses' => 'SettingsController@clearCache']);
 
   # Emails
   Route::get('email', ['as' => 'emails', 'uses' => 'EmailController@index']);

--- a/app/views/admin/layouts/partials/subnav-settings.blade.php
+++ b/app/views/admin/layouts/partials/subnav-settings.blade.php
@@ -8,6 +8,6 @@
     <li class="{{ setActive('email', 2, 'active') }}">{{ link_to_route('emails', 'Emails') }}</li>
   </ul>
   {{ Form::open(array('route' => 'general.clear-cache')) }}
-    {{ Form::submit('Clear Cache', ['class' => 'btn btn-primary btn-large']) }}
+    {{ Form::submit('Clear Cache', ['class' => 'btn btn-default -hover-red']) }}
   {{ Form::close() }}
 </div>

--- a/app/views/admin/layouts/partials/subnav-settings.blade.php
+++ b/app/views/admin/layouts/partials/subnav-settings.blade.php
@@ -7,4 +7,7 @@
     <li class="{{ setActive('winners', 3, 'active') }}">{{ link_to_route('admin.winner.index', 'Winners') }}</li>
     <li class="{{ setActive('email', 2, 'active') }}">{{ link_to_route('emails', 'Emails') }}</li>
   </ul>
+  {{ Form::open(array('route' => 'general.clear-cache')) }}
+    {{ Form::submit('Clear Cache', ['class' => 'btn btn-primary btn-large']) }}
+  {{ Form::close() }}
 </div>


### PR DESCRIPTION
Fixes #680 

Creates a `clear cache` button on the admin side panel that will allow admins to clear the cache from the UI. After the cache is cleared, we reset any custom appearance settings.

@weerd @angaither 