### PR TITLE
New command to help wipe database of prior users.

### DIFF
--- a/app/commands/DatabaseWipeCommand.php
+++ b/app/commands/DatabaseWipeCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class WipeDatabaseCommand extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'wipe:users';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Command description.';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function fire()
+	{
+		if (! $this->confirm('Did you run a dump and back up the current database? [y|n]')) {
+			return $this->error('Please back up the current database before proceeding!');
+		}
+
+		// Do the thing here:
+		// applications ✓
+		// nominations ✓
+		// failed_jobs ✓
+		// password_reminders ✓
+		// profiles ✓
+		// races ✓
+		// ratings ✓
+		// recommendation_tokens ✓
+		// recommendations ✓
+		// users
+
+
+		Application::truncate();
+		Nomination::truncate();
+		Profile::truncate();
+		Race::truncate();
+		Rating::truncate();
+		Recommendation::truncate();
+		RecommendationToken::truncate();
+		// Users::truncate();
+
+
+		DB::table('failed_jobs')->truncate();
+		DB::table('password_reminders')->truncate();
+
+
+		$this->info('All set! We successfully killed all the user data with fire.');
+	
+	}
+
+}

--- a/app/commands/DatabaseWipeCommand.php
+++ b/app/commands/DatabaseWipeCommand.php
@@ -45,7 +45,7 @@ class WipeDatabaseCommand extends Command {
 			return $this->error('Please back up the current database before proceeding!');
 		}
 
-		// Get the dmins from the Users table.
+		// Get the admins from the Users table.
 		$admins = DB::select(DB::raw('SELECT *
 						                      FROM users u
 						                      INNER JOIN role_user ru

--- a/app/controllers/WinnerController.php
+++ b/app/controllers/WinnerController.php
@@ -9,13 +9,15 @@ class WinnerController extends \BaseController {
   {
     $filter_by = Request::get('filter_by');
 
-    $query = DB::table('winners')
-                         ->join('users', 'winners.user_id', '=', 'users.id');
+    $query = DB::table('winners');
+
     if ($filter_by) {
       $query->where('winners.scholarship_id', '=', $filter_by);
     }
 
     $winners = $query->get();
+
+    // dd($winners);
 
     $scholarships = Scholarship::all();
     return View::make('admin.winners.index', compact('winners', 'scholarships'));
@@ -53,12 +55,17 @@ class WinnerController extends \BaseController {
    */
   public function edit($id)
   {
-    $winner = Winner::with('user')->where('user_id', $id)->firstOrFail();
+    $winner = Winner::findOrFail($id);
 
     return View::make('admin.winners.edit', compact('winner'));
   }
 
 
+  /**
+   * Update the specified resource.
+   * 
+   * @return Response
+   */
   public function update($id)
   {
     $input = Input::except('photo');

--- a/app/controllers/WinnerController.php
+++ b/app/controllers/WinnerController.php
@@ -17,8 +17,6 @@ class WinnerController extends \BaseController {
 
     $winners = $query->get();
 
-    // dd($winners);
-
     $scholarships = Scholarship::all();
     return View::make('admin.winners.index', compact('winners', 'scholarships'));
   }

--- a/app/start/artisan.php
+++ b/app/start/artisan.php
@@ -14,3 +14,5 @@
 Artisan::add(new CustomStylesCommand);
 
 Artisan::add(new TransferWinnersCommand);
+
+Artisan::add(new WipeDatabaseCommand);

--- a/app/views/admin/winners/edit.blade.php
+++ b/app/views/admin/winners/edit.blade.php
@@ -9,7 +9,7 @@
 
       <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
         <h1 class="page-header">
-        {{ $winner->user->first_name . ' ' . $winner->user->last_name }}
+        {{ $winner->first_name . ' ' . $winner->last_name }}
         </h1>
 
         {{ Form::model($winner, ['method' => 'PATCH', 'route' => ['admin.winner.update', $winner->id], 'files' => TRUE, 'class' => 'col-md-8']) }}

--- a/app/views/admin/winners/index.blade.php
+++ b/app/views/admin/winners/index.blade.php
@@ -23,17 +23,16 @@
           <table class="table table-striped">
             <thead>
               <tr>
-                <th> ID (edit user info) </th>
-                <th> Name (edit winner info)</th>
-                <th> College </th>
+                <th>Winner ID</th>
+                <th>Name (edit winner info)</th>
+                <th>College</th>
               </tr>
               </thead>
             <tbody>
             @foreach ($winners as $winner)
             <tr>
-              <td>{{ link_to_route('admin.application.show', $winner->user_id, array($winner->user_id))  }}</td>
-
-              <td>{{ link_to_route('admin.winner.edit', $winner->first_name . ' ' . $winner->last_name, array($winner->user_id)) }}</td>
+              <td>{{ $winner->id  }}</td>
+              <td>{{ link_to_route('admin.winner.edit', $winner->first_name . ' ' . $winner->last_name, [$winner->id]) }}</td>
               <td>{{ $winner->college }}</td>
             </tr>
             @endforeach

--- a/app/views/pages/partials/_winners-gallery.blade.php
+++ b/app/views/pages/partials/_winners-gallery.blade.php
@@ -18,7 +18,7 @@
               </ul>
             </div>
             <figure>
-              <img src="{{ $winner->photo }}" alt="Image of scholarship winner {{ $winner->user->first_name . ' ' . $winner->user->last_name }}">
+              <img src="{{ $winner->photo }}" alt="Image of scholarship winner {{ $winner->first_name . ' ' . $winner->last_name }}">
               <figcaption>{{ $winner->first_name }}</figcaption>
             </figure>
             <div class="__body"> {{ $winner->description }} </div>


### PR DESCRIPTION
### Fixes #670

This PR creates a new Artisan command `wipe:applicants` which goes through and eliminates all the user related data for prior scholarship year's applications, while leaving all the site data and winners data intact.

Since all applicant data is getting cleared out, this PR also updates a few views and controllers to properly load the winners data that was transfered and modified in #681.

_NOTE: Once merged, we will need to run the `php artisan transfer:winners` command so that the views don't break (gallery on home page and winners pages in admin)_

---
@angaither @sbsmith86 