### PR TITLE
Dedupe the recommender's query

### DIFF
--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -86,7 +86,7 @@ class Export extends Eloquent {
 
   public static function recommenders_query()
   {
-    $results = DB::select('SELECT first_name, email
+    $results = DB::select('SELECT DISTINCT first_name, email
                           FROM recommendations
                           WHERE rank_character IS NOT null');
 


### PR DESCRIPTION
Resolves #665 

Added `SELECT DISTINCT` to the SQL query that is getting the past recommenders because I was seeing dupes in my  dev and qa databases. The dupes were because a person could be a recommendation for multiple people. 