### PR TITLE
Add application year to winner filter by dropdown

### DIFF
--- a/app/views/admin/winners/index.blade.php
+++ b/app/views/admin/winners/index.blade.php
@@ -14,7 +14,7 @@
           <a data-toggle="dropdown" href="#">Scholarship <span class='glyphicon glyphicon-chevron-down'/> </a>
           <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
               @foreach($scholarships as $scholarship)
-                <li> {{ filter_winners_by($scholarship->id, $scholarship->title) }} </li>
+                <li> {{ filter_winners_by($scholarship->id, $scholarship->title . ' ' . date("Y", strtotime($scholarship->application_start))) }} </li>
               @endforeach
           </ul>
         </div>


### PR DESCRIPTION
Fixes #687 

Appending the year that the scholarship started to the name of the scholarship in the dropdown menu on admin/winner. 

@weerd @angaither 