### PR TITLE
Scholarship dates

### DIFF
--- a/app/models/Scholarship.php
+++ b/app/models/Scholarship.php
@@ -49,17 +49,9 @@ class Scholarship extends \Eloquent {
    * @param  $type  Check dates for either the application or the nomination period.
    * @return boolean - True if closed, else false.
    */
-  public static function isOpen($type = 'application')
+  public static function isOpen()
   {
-    if ($type === 'application') {
-      $start_date = self::getCurrentScholarship()->application_start;
-    }
-
-    if ($type === 'nomination') {
-      $start_date = self::getCurrentScholarship()->nomination_start;
-    }
-
-    return date_has_expired($start_date);
+    return date_has_expired(self::getCurrentScholarship()->application_start);
   }
 
 

--- a/app/models/Scholarship.php
+++ b/app/models/Scholarship.php
@@ -43,6 +43,25 @@ class Scholarship extends \Eloquent {
     return date_has_expired($end_date);
   }
 
+  /**
+   * Determine if the current scholarship application or nomination is open.
+   *
+   * @param  $type  Check dates for either the application or the nomination period.
+   * @return boolean - True if closed, else false.
+   */
+  public static function isOpen($type = 'application')
+  {
+    if ($type === 'application') {
+      $start_date = self::getCurrentScholarship()->application_start;
+    }
+
+    if ($type === 'nomination') {
+      $start_date = self::getCurrentScholarship()->nomination_start;
+    }
+
+    return date_has_expired($start_date);
+  }
+
 
   /**
    * Get all labels for a scholarship.

--- a/app/views/pages/home.blade.php
+++ b/app/views/pages/home.blade.php
@@ -17,7 +17,7 @@
     @endforeach
 
     {{-- Only include nomination form if still open. --}}
-    @if(!Scholarship::isClosed('nomination'))
+    @if(!Scholarship::isClosed('nomination') && Scholarship::isOpen())
       @include('pages.partials._nomination-form')
     @endif
 

--- a/app/views/pages/partials/_block_cta.blade.php
+++ b/app/views/pages/partials/_block_cta.blade.php
@@ -11,7 +11,7 @@
       {{ $block->block_body_html }}
     @endif
 
-    @if($url === 'home' && !Scholarship::isClosed())
+    @if($url === 'home' && !Scholarship::isClosed() && Scholarship::isOpen())
       <div class="fragment">
         @if (Auth::guest())
           {{ link_to_route('registration.create', 'Start Application', null, ['class' => 'button -default']) }}


### PR DESCRIPTION
#### What's this PR do?

This PR adds an additional check to see if an application `isOpen()` before outputting the application cta block and the nomination block on the homepage.

#### Where should the reviewer start?

In `app/models/Scholarship.php` I add a new function `isOpen()` and then use that function to check if an application is open in the other blade templates.

#### How should this be manually tested?

Create a scholarship with an application start date that is set in the future :rocket: and you should not see a "continue application" button or the nomination form on the homepage. On the flip side, set the application start and end dates to be before and after the current date, and the button and form should appear. 

#### What are the relevant tickets?

#693 