### PR TITLE
Get labels for correct scholarships.

### DIFF
--- a/app/controllers/ApplicationController.php
+++ b/app/controllers/ApplicationController.php
@@ -34,7 +34,8 @@ class ApplicationController extends \BaseController {
   public function create()
   {
     //@TODO: need to figure out which scholarship is the current run.
-    $label = Scholarship::getScholarshipLabels();
+    $current_scholarship_id = Scholarship::getCurrentScholarship()->id;
+    $label = Scholarship::getScholarshipLabels($current_scholarship_id);
     $hear_about = Scholarship::getCurrentScholarship()->pluck('hear_about_options');
 
     $choices = Application::formatChoices($hear_about);
@@ -119,10 +120,11 @@ class ApplicationController extends \BaseController {
   public function edit($id)
   {
     // @TODO: add a filter here to check for app complete.
-    $user       = User::whereId($id)->firstOrFail();
-    $label      = Scholarship::getScholarshipLabels();
-    $hear_about = Scholarship::getCurrentScholarship()->pluck('hear_about_options');
-    $choices    = Application::formatChoices($hear_about);
+    $user        = User::whereId($id)->firstOrFail();
+    $application = Application::getUserApplication($id);
+    $label       = Scholarship::getScholarshipLabels($application['scholarship_id']);
+    $hear_about  = Scholarship::getCurrentScholarship()->pluck('hear_about_options');
+    $choices     = Application::formatChoices($hear_about);
 
     $vars = (object) $this->settings->getSpecifiedSettingsVars(['application_create_help_text']);
 

--- a/app/controllers/StatusController.php
+++ b/app/controllers/StatusController.php
@@ -92,7 +92,7 @@ class StatusController extends \BaseController {
     // Get all the things.
     $application = Application::getUserApplication($id);
     $profile = Profile::getUserProfile($id);
-    $scholarship = Scholarship::getScholarshipLabels();
+    $scholarship = Scholarship::getScholarshipLabels($application['scholarship_id']);
 
     $vars = (object) $this->settings->getSpecifiedSettingsVars(['application_submit_help_text']);
 

--- a/app/controllers/admin/AdminController.php
+++ b/app/controllers/admin/AdminController.php
@@ -157,7 +157,7 @@ class AdminController extends \BaseController {
     $application = Application::getUserApplication($id);
     $profile = Profile::getUserProfile($id);
     $user = User::getUserInfo($id);
-    $scholarship = Scholarship::getScholarshipLabels();
+    $scholarship = Scholarship::getScholarshipLabels($application['scholarship_id']);
     $app_id = Application::getUserApplicationId($id);
     $prof_id = Profile::getUserProfileId($id);
     $races = Profile::getUserRace($prof_id);
@@ -183,7 +183,7 @@ class AdminController extends \BaseController {
     $application = Application::getUserApplication($id);
     $user_info = User::getUserInfo($id);
     $profile = Profile::with('race')->whereUserId($id)->firstOrFail();
-    $label = Scholarship::getScholarshipLabels();
+    $label = Scholarship::getScholarshipLabels($application['scholarship_id']);
     $app_id = Application::getUserApplicationId($id);
     $races = Profile::getRaces();
     $states = Profile::getStates();

--- a/app/models/Scholarship.php
+++ b/app/models/Scholarship.php
@@ -46,8 +46,10 @@ class Scholarship extends \Eloquent {
 
   /**
    * Get all labels for a scholarship.
+   * @param integer $id Scholarship ID.
+   * @return array Array of application labels.
    */
-  public static function getScholarshipLabels()
+  public static function getScholarshipLabels($id)
   {
     $fields = array('label_app_accomplishments as accomplishments',
                     'label_app_activities as activities',
@@ -59,7 +61,8 @@ class Scholarship extends \Eloquent {
                     'label_rec_essay1 as rec_essay1',
                     'label_rec_optional_question as rec_optional_question'
                     );
-    return Scholarship::getCurrentScholarship()->select($fields)->first()->toArray();
+
+    return Scholarship::where('id', '=', $id)->select($fields)->first()->toArray();
   }
 
 


### PR DESCRIPTION
#### What's this PR do?

This PR updates `getScholarshipLabels()` to take an `$id` parameter and updates the eloquent query it uses to first select the correct scholarship based on the `$id` and grab the labels for the application for that scholarship. 

In this PR, I also update calls to `getScholarshipLabels()` to use the $id parameter to get labels for the correct scholarship.

#### Where should the reviewer start?

I would start at `app/models/Scholarship.php`. This is where I update the function to take in a parameter.

Other changes are for updating calls to `getScholarshipLabels()`

#### How should this be manually tested?

go to `/application/create` and you should see the label correlating to the current active scholarship. 

Also, go to view an old users application, and you should see the labels for the scholarship they applied for at the time.

#### Any background context you want to provide?

Previously, the function was always returning the labels of the first scholarship created because it was it was running `select($fields)` on the eloquent collection returned by `getCurrentScholarship()`. This returned the labels for each of the scholarship applications so when running `first()` only the first (the first scholarship created) result was pulled. 

#### What are the relevant tickets?

Fixes #694 