### PR TITLE
Don't show the apply label before scholarship is open

### DIFF
--- a/app/views/layouts/partials/navigation.blade.php
+++ b/app/views/layouts/partials/navigation.blade.php
@@ -8,7 +8,7 @@
 
       @if (Auth::guest())
          <li class="{{ setActive('login') }}"><a href="/login"><span>Log in</span></a></li>
-        @if (!Scholarship::isClosed())
+        @if (!Scholarship::isClosed() && Scholarship::isOpen())
           <li class="{{ setActive('register') }}"><a href="/register"><span>Apply</span></a></li>
         @endif
       @else


### PR DESCRIPTION
'apply' in the top nav was showing up because the scholarship was checking if closed, but not if it was open yet. 

Fixes #693