### PR TITLE
do not allow anonymous users to access recommendation/create

### DIFF
--- a/app/controllers/RecommendationController.php
+++ b/app/controllers/RecommendationController.php
@@ -34,6 +34,10 @@ class RecommendationController extends \BaseController {
 
     $vars = (object) $this->settings->getSpecifiedSettingsVars(['recommendation_create_help_text']);
 
+    if(!Auth::check()){
+      return Redirect::home()->with('flash_message', ['text' => 'You are not authorized to access that page!', 'class' => '-warning']);
+    }
+
     return View::make('recommendation.create', compact('num_recs', 'vars'));
   }
 

--- a/app/controllers/RecommendationController.php
+++ b/app/controllers/RecommendationController.php
@@ -18,6 +18,8 @@ class RecommendationController extends \BaseController {
     $this->beforeFilter('isClosed');
     // Check that the current user doesn't create many applications
     $this->beforeFilter('createdRec', ['only' => ['create']]);
+    // check that the user is logged in
+    $this->beforeFilter('auth');
   }
 
 
@@ -33,10 +35,6 @@ class RecommendationController extends \BaseController {
     $num_recs = Scholarship::getCurrentScholarship()->select('num_recommendations_max', 'num_recommendations_min')->firstOrFail()->toArray();
 
     $vars = (object) $this->settings->getSpecifiedSettingsVars(['recommendation_create_help_text']);
-
-    if(!Auth::check()){
-      return Redirect::home()->with('flash_message', ['text' => 'You are not authorized to access that page!', 'class' => '-warning']);
-    }
 
     return View::make('recommendation.create', compact('num_recs', 'vars'));
   }

--- a/app/controllers/RecommendationController.php
+++ b/app/controllers/RecommendationController.php
@@ -18,8 +18,9 @@ class RecommendationController extends \BaseController {
     $this->beforeFilter('isClosed');
     // Check that the current user doesn't create many applications
     $this->beforeFilter('createdRec', ['only' => ['create']]);
-    // check that the user is logged in
-    $this->beforeFilter('auth');
+
+    // check that the user is logged in before allowing them to create a recommendation
+    $this->beforeFilter('auth', ['only' => 'create']);
   }
 
 

--- a/app/views/recommendation/create.blade.php
+++ b/app/views/recommendation/create.blade.php
@@ -1,4 +1,4 @@
-{{-- Reecommendation Request --}}
+{{-- Recommendation Request --}}
 
 @extends('layouts.master')
 


### PR DESCRIPTION
fixes #717 

only authenticated uses can view the recommendation/create page.

Recommenders end up being authenticated users, right? If not this would end up blocking them. I tested as anonymous and logged in, but I couldn't test as a recommender because I was unable to login as one.

There is an error when admins try to view this page which was happening before and after my changes.