### PR TITLE
Mark app complete

### DIFF
--- a/app/controllers/admin/AdminController.php
+++ b/app/controllers/admin/AdminController.php
@@ -242,7 +242,7 @@ class AdminController extends \BaseController {
     return Redirect::to(Session::get('url.index'))->with('flash_message', ['text' => '<strong>Success:</strong> Awesome, we got that rated for you!', 'class' => 'alert-success']);
   }
 
-  public function makeComplete()
+  public function complete()
   {
     $app_id = Input::get('app_id');
     $application = Application::whereId($app_id)->firstOrFail();

--- a/app/controllers/admin/AdminController.php
+++ b/app/controllers/admin/AdminController.php
@@ -249,7 +249,7 @@ class AdminController extends \BaseController {
     $application->completed = 1;
     $application->save();
 
-    return Redirect::back();
+    return Redirect::to(Session::get('url.index'))->with('flash_message', ['text' => '<strong>Success:</strong> App marked as completed!', 'class' => 'alert-success']);
   }
 
   public function export()

--- a/app/controllers/admin/AdminController.php
+++ b/app/controllers/admin/AdminController.php
@@ -249,7 +249,7 @@ class AdminController extends \BaseController {
     $application->completed = 1;
     $application->save();
 
-    return Redirect::to('admin.applications');
+    return Redirect::route('applications.index');
   }
 
   public function export()

--- a/app/controllers/admin/AdminController.php
+++ b/app/controllers/admin/AdminController.php
@@ -249,7 +249,7 @@ class AdminController extends \BaseController {
     $application->completed = 1;
     $application->save();
 
-    return Redirect::route('applications.index');
+    return Redirect::back();
   }
 
   public function export()

--- a/app/controllers/admin/AdminController.php
+++ b/app/controllers/admin/AdminController.php
@@ -242,6 +242,16 @@ class AdminController extends \BaseController {
     return Redirect::to(Session::get('url.index'))->with('flash_message', ['text' => '<strong>Success:</strong> Awesome, we got that rated for you!', 'class' => 'alert-success']);
   }
 
+  public function makeComplete()
+  {
+    $app_id = Input::get('app_id');
+    $application = Application::whereId($app_id)->firstOrFail();
+    $application->completed = 1;
+    $application->save();
+
+    return Redirect::to('admin.applications');
+  }
+
   public function export()
   {
     return View::make('admin.reports.export');

--- a/app/routes.php
+++ b/app/routes.php
@@ -59,7 +59,7 @@ Route::group(['before' => 'role:administrator', 'prefix' => 'admin'], function()
   Route::get('applications/{id}/edit', ['as' => 'admin.application.edit', 'uses' => 'AdminController@applicationsEdit']);
 
   Route::post('application/rate', ['as' => 'applications.rate', 'uses' => 'AdminController@rate']);
-  Route::post('application/makeComplete', ['as' => 'applications.makeComplete', 'uses' => 'AdminController@makeComplete']);
+  Route::post('application/complete', ['as' => 'applications.complete', 'uses' => 'AdminController@complete']);
 
   # Winners
   Route::resource('winner', 'WinnerController');

--- a/app/routes.php
+++ b/app/routes.php
@@ -59,6 +59,7 @@ Route::group(['before' => 'role:administrator', 'prefix' => 'admin'], function()
   Route::get('applications/{id}/edit', ['as' => 'admin.application.edit', 'uses' => 'AdminController@applicationsEdit']);
 
   Route::post('application/rate', ['as' => 'applications.rate', 'uses' => 'AdminController@rate']);
+  Route::post('application/makeComplete', ['as' => 'applications.makeComplete', 'uses' => 'AdminController@makeComplete']);
 
   # Winners
   Route::resource('winner', 'WinnerController');

--- a/app/views/admin/applications/show.blade.php
+++ b/app/views/admin/applications/show.blade.php
@@ -117,7 +117,13 @@
                 @endif
               </div>
             @endif
+            @else
+              {{ Form::open(['route' => 'applications.makeComplete']) }}
+              {{ Form::hidden('app_id', $app_id->id)}}
+              {{ Form::submit(('Mark as complete'), ['class' => 'btn btn-default btn-md']) }}
+              {{ Form::close() }}
           @endif
+
 
         </div>
       </div>

--- a/app/views/admin/applications/show.blade.php
+++ b/app/views/admin/applications/show.blade.php
@@ -118,7 +118,7 @@
               </div>
             @endif
             @else
-              {{ Form::open(['route' => 'applications.makeComplete']) }}
+              {{ Form::open(['route' => 'applications.complete']) }}
               {{ Form::hidden('app_id', $app_id->id)}}
               {{ Form::submit(('Mark as complete'), ['class' => 'btn btn-default btn-md']) }}
               {{ Form::close() }}


### PR DESCRIPTION
fixes #723 

added a button to the bottom of an application to allow admins to mark an app as complete.
if the app is currently not complete, it looks like this:
![image](https://cloud.githubusercontent.com/assets/4240292/11572637/435a2fe6-99d0-11e5-840e-ff246742b84f.png)

once that is clicked, if you return to the same application, it looks like this:
![image](https://cloud.githubusercontent.com/assets/4240292/11572659/5c2cd62c-99d0-11e5-9be8-d642595c9e61.png)
