### PR TITLE
fix admin edit app from crashing when there isn't an app or rec

### DIFF
--- a/app/controllers/admin/AdminController.php
+++ b/app/controllers/admin/AdminController.php
@@ -188,7 +188,9 @@ class AdminController extends \BaseController {
     $application = Application::getUserApplication($id);
     $user_info = User::getUserInfo($id);
     $profile = Profile::with('race')->whereUserId($id)->firstOrFail();
-    $label = Scholarship::getScholarshipLabels($application['scholarship_id']);
+    if (isset($application)) {
+      $label = Scholarship::getScholarshipLabels($application['scholarship_id']);
+    }
     $app_id = Application::getUserApplicationId($id);
     $races = Profile::getRaces();
     $states = Profile::getStates();
@@ -206,10 +208,11 @@ class AdminController extends \BaseController {
 
 
     $show_rating = FALSE;
-    if (Application::isComplete($app_id->id))
+    if (isset($application) && Application::isComplete($app_id->id)) {
       $show_rating = TRUE;
+      $app_rating = Rating::getApplicationRating($app_id->id);
+    }
 
-    $app_rating = Rating::getApplicationRating($app_id->id);
     $possible_ratings = Rating::getPossibleRatings();
 
     return View::make('admin.applications.edit')->withUser($profile)->with(compact('id', 'application', 'app_id', 'user', 'user_info', 'profile', 'races', 'label', 'choices', 'recomendations', 'states', 'show_rating', 'possible_ratings', 'app_rating', 'rank_values'));

--- a/app/views/admin/applications/edit.blade.php
+++ b/app/views/admin/applications/edit.blade.php
@@ -22,6 +22,7 @@
           {{ Form::close() }}
          </div>
 
+        @if (!is_null($application))
           <h2>Application</h2>
           <div class="details well well-lg">
             {{ Form::model($application, ['method' => 'PATCH', 'route' => ['application.update', $id], 'class' => 'form--application']) }}
@@ -29,13 +30,16 @@
               {{ Form::submit('Update info', ['class' => 'btn btn-primary', 'name' => 'complete']) }}
             {{ Form::close() }}
           </div>
+        @endif
 
+        @if (!is_null($recomendations) && count($recomendations) > 0)
           <h2>Recommender Responses</h2>
           <div class="well well-lg">
              @foreach ($recomendations as $rec)
                   @include('admin/recommendations/edit', array('recommendation' => (object)$rec, 'label' => (object)$label))
               @endforeach
           </div>
+        @endif
 
         </div>
       </div>


### PR DESCRIPTION
this is essentially the same fix we made to the "show" view (https://github.com/DoSomething/longshot/pull/722)

edit view was crashing when there wasn't an app or recs