### PR TITLE
fix wipe:appliants to work when there is no failed_jobs table

### DIFF
--- a/app/commands/DatabaseWipeCommand.php
+++ b/app/commands/DatabaseWipeCommand.php
@@ -63,7 +63,9 @@ class WipeDatabaseCommand extends Command {
 		Recommendation::truncate();
 		RecommendationToken::truncate();
 		User::truncate();
-		DB::table('failed_jobs')->truncate();
+		if((Schema::hasTable('failed_jobs'))) {
+			DB::table('failed_jobs')->truncate();
+		}
 		DB::table('password_reminders')->truncate();
 
 


### PR DESCRIPTION
fixes #735 

Older instances don't necessarily have a failed_jobs table, so now we check if the table exists before trying to truncate it. The command was crashing after it tried to truncate the table that didn't exist, which is before the admins got added back in so it was causing that issue as well.