### PR TITLE
users can edit rec info

### DIFF
--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -63,7 +63,7 @@ class RecommendationController extends \Controller
    *
    * @return Response
    */
-  public function store()
+  public function store(Request $request)
   {
       dd('storing');
       $input = Input::all();

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -85,8 +85,8 @@ class RecommendationController extends \Controller
               $recommendation->save();
 
               $token = $recommendation->generateRecToken($recommendation);
-              // $this->prepareRecRequestConfirmationEmail($recommendation);
-              // $this->prepareRecRequestEmail($recommendation, $token);
+              $this->prepareRecRequestConfirmationEmail($recommendation);
+              $this->prepareRecRequestEmail($recommendation, $token);
             }
           }
 
@@ -190,7 +190,7 @@ class RecommendationController extends \Controller
     $application = Application::whereId($recommendation->application_id)->firstOrFail();
     $application->completed = 1;
     $application->save();
-    // $this->prepareRecReceivedEmail($recommendation);
+    $this->prepareRecReceivedEmail($recommendation);
 
     return redirect()->route('home')->with('flash_message', ['text' => 'Thanks, we got your recommendation!', 'class' => '-success']);
   }
@@ -232,8 +232,8 @@ class RecommendationController extends \Controller
             if($currentRec->isDirty('email'))
             {
               $token = RecommendationToken::where('recommendation_id', $rec['id'])->pluck('token');
-              // $this->prepareRecRequestEmail($currentRec, $token);
-              // $this->prepareRecRequestConfirmationEmail($currentRec);
+              $this->prepareRecRequestEmail($currentRec, $token);
+              $this->prepareRecRequestConfirmationEmail($currentRec);
             }
             $currentRec->save();
         } else {
@@ -250,8 +250,8 @@ class RecommendationController extends \Controller
               $newRec->fill($rec);
               $newRec->save();
               $token = $newRec->generateRecToken($newRec);
-              // $this->prepareRecRequestConfirmationEmail($newRec);
-              // $this->prepareRecRequestEmail($newRec, $token);
+              $this->prepareRecRequestConfirmationEmail($newRec);
+              $this->prepareRecRequestEmail($newRec, $token);
             }
         }
       }

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -236,7 +236,7 @@ class RecommendationController extends \Controller
               $v = Validator::make($rec, $this->applicant_rules);
               if($v->fails())
               {
-                return  redirect()->back()->with('flash_message', ['text' => 'You must fill out all fields for the recommendations that you are requesting.', 'class' => '-error'])->withInput();
+                return redirect()->back()->with('flash_message', ['text' => 'You must fill out all fields for the recommendations that you are requesting.', 'class' => '-error'])->withInput();
               }
               $newRec = new Recommendation();
               $application = Auth::user()->application;

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -70,7 +70,7 @@ class StatusController extends \Controller
       $recommendations = Recommendation::where('application_id', $application->id)->get();
           $max_recs = Scholarship::getCurrentScholarship()->value('num_recommendations_max');
           if ($recommendations->count() < $max_recs) {
-              $add_rec_link = link_to_route('recommendation.create', 'Ask for another recommendation', null, ['class' => 'button -small']);
+              $add_rec_link = link_to_route('recommendation.create', 'Edit Or Add Recommendation Request', null, ['class' => 'button -small']);
           }
           foreach ($recommendations as $rec) {
               $rec->isRecommendationComplete($rec);

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -61,26 +61,26 @@ class StatusController extends \Controller
         $help_text = $this->settings->getSpecifiedSettingsVars(['status_page_help_text_incomplete'])['status_page_help_text_incomplete'];
     }
 
-      $profile = Profile::where('user_id', $user->id)->first();
-      if ($profile) {
-          $prof_complete = Profile::isComplete($user->id);
-      }
-      if ($application) {
-          // Get recommendations
-      $recommendations = Recommendation::where('application_id', $application->id)->get();
-          $max_recs = Scholarship::getCurrentScholarship()->value('num_recommendations_max');
-          if ($recommendations->count() < $max_recs) {
-              $add_rec_link = link_to_route('recommendation.create', 'Edit Or Add Recommendation Request', null, ['class' => 'button -small']);
-          }
-          foreach ($recommendations as $rec) {
-              $rec->isRecommendationComplete($rec);
-              if ($rec->isComplete($rec->id) && isset($app_filled_out) && $application->submitted) {
-                  $status = 'Completed.';
-                  $help_text = $this->settings->getSpecifiedSettingsVars(['status_page_help_text_complete'])['status_page_help_text_complete'];
-              }
-          }
-          $recommendations = $recommendations->toArray();
-      }
+    $profile = Profile::where('user_id', $user->id)->first();
+    if ($profile) {
+        $prof_complete = Profile::isComplete($user->id);
+    }
+    if ($application) {
+        // Get recommendations
+    $recommendations = Recommendation::where('application_id', $application->id)->get();
+        $max_recs = Scholarship::getCurrentScholarship()->value('num_recommendations_max');
+        if ($recommendations->count() < $max_recs) {
+            $add_rec_link = link_to_route('recommendation.create', 'Ask for another recommendation', null, ['class' => 'button -small']);
+        }
+        foreach ($recommendations as $rec) {
+            $rec->isRecommendationComplete($rec);
+            if ($rec->isComplete($rec->id) && isset($app_filled_out) && $application->submitted) {
+                $status = 'Completed.';
+                $help_text = $this->settings->getSpecifiedSettingsVars(['status_page_help_text_complete'])['status_page_help_text_complete'];
+            }
+        }
+        $recommendations = $recommendations->toArray();
+    }
 
     // If both app & profile are complete add a link to review & submit.
     if ($app_filled_out && $prof_complete && !($application->submitted)) {

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -78,7 +78,6 @@ class StatusController extends \Controller
                 $help_text = $this->settings->getSpecifiedSettingsVars(['status_page_help_text_complete'])['status_page_help_text_complete'];
             }
         }
-        $recommendations = $recommendations->toArray();
     }
 
     // If both app & profile are complete add a link to review & submit.

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -67,11 +67,10 @@ class StatusController extends \Controller
     }
     if ($application) {
         // Get recommendations
-    $recommendations = Recommendation::where('application_id', $application->id)->get();
-        $max_recs = Scholarship::getCurrentScholarship()->value('num_recommendations_max');
-        if ($recommendations->count() < $max_recs) {
-            $add_rec_link = link_to_route('recommendation.create', 'Ask for another recommendation', null, ['class' => 'button -small']);
-        }
+        $recommendations = Recommendation::where('application_id', $application->id)->get();
+        $max_recs = Scholarship::getCurrentScholarship()->num_recommendations_max;
+        $add_rec_link = link_to_route('recommendation.create', 'Add or Update Recommendations', null, ['class' => 'button -small']);
+
         foreach ($recommendations as $rec) {
             $rec->isRecommendationComplete($rec);
             if ($rec->isComplete($rec->id) && isset($app_filled_out) && $application->submitted) {
@@ -157,9 +156,9 @@ class StatusController extends \Controller
         $link = link_to_route('recommendation.edit', 'Please provide a recommendation', [$recommendation->id, 'token' => $token]);
         $email = new Email();
         $data = [
-      'link'           => $link,
-      'applicant_name' => Auth::user()->first_name.' '.Auth::user()->last_name,
-      ];
+          'link'           => $link,
+          'applicant_name' => Auth::user()->first_name.' '.Auth::user()->last_name,
+        ];
         $email->sendEmail('request', 'recommender', $recommendation->email, $data);
 
         return redirect()->route('status')->with('flash_message', ['text' => 'We sent another email!', 'class' => '-success']);

--- a/app/Http/Middleware/CheckIfRecRequested.php
+++ b/app/Http/Middleware/CheckIfRecRequested.php
@@ -6,8 +6,6 @@ use App\Models\User;
 use App\Models\Application;
 use App\Models\Recommendation;
 use Illuminate\Database\Eloquent\Model;
-
-
 use Auth;
 
 class CheckIfRecRequested

--- a/app/Http/Middleware/CheckIfRecRequested.php
+++ b/app/Http/Middleware/CheckIfRecRequested.php
@@ -36,7 +36,7 @@ class CheckIfRecRequested
               $recommendations = Recommendation::where('application_id', $application->id)->get()->toArray();
 
               if (!empty($recommendations)) {
-                  return Redirect::route('recommendation.edit', ['user' => $user->id, 'app_id' => $application->id]);
+                  return redirect()->route('recommendation.edit', ['user' => $user->id, 'app_id' => $application->id]);
               }
           }
 

--- a/resources/views/recommendation/applicant_edit.blade.php
+++ b/resources/views/recommendation/applicant_edit.blade.php
@@ -29,9 +29,46 @@
                 @endif
               </h2>
             @endif
-            @if (isset($recs[$i]))
+            @if (in_array($recs[$i]['id'], $complete_recs))
             {{ Form::hidden('rec['.$i.'][id]', $recs[$i]['id']) }}
             {{-- First Name --}}
+            <div class="field-group -dual -alpha">
+              {{ Form::label('rec['.$i.'][first_name]', 'First Name: ') }}
+              {{ Form::text('rec['.$i.'][first_name]', $recs[$i]['first_name'], ['disabled']) }}
+              {{ errorsFor('rec['.$i.'][first_name]', $errors) }}
+            </div>
+
+            {{-- Last Name --}}
+            <div class="field-group -dual -beta">
+              {{ Form::label('rec['.$i.'][last_name]', 'Last Name: ') }}
+              {{ Form::text('rec['.$i.'][last_name]', $recs[$i]['last_name'], ['disabled'])  }}
+              {{ errorsFor('rec['.$i.'][last_name]', $errors) }}
+            </div>
+
+            {{-- Email --}}
+            <div class="field-group -dual -alpha">
+              {{ Form::label('rec['.$i.'][email]', 'Email: ') }}
+              {{ Form::email('rec['.$i.'][email]', $recs[$i]['email'], ['disabled']) }}
+              {{ errorsFor('rec['.$i.'][email]', $errors) }}
+            </div>
+
+            {{-- Phone Number --}}
+            <div class="field-group -dual -beta">
+              {{ Form::label('rec['.$i.'][phone]', 'Phone Number: ') }}
+              {{ Form::text('rec['.$i.'][phone]', $recs[$i]['phone'], ['disabled']) }}
+              {{ errorsFor('rec['.$i.'][phone]', $errors) }}
+            </div>
+
+             {{-- Relationship --}}
+            <div class="field-group -mono">
+              {{ Form::label('rec['.$i.'][relationship]', 'Relationship to you: ') }}
+              {{ Form::text('rec['.$i.'][relationship]', $recs[$i]['relationship'], ['disabled']) }}
+              {{ errorsFor('rec['.$i.'][relationship]', $errors) }}
+            </div>
+
+            @elseif (isset($recs[$i]))
+            {{ Form::hidden('rec['.$i.'][id]', $recs[$i]['id']) }}
+              {{-- First Name --}}
             <div class="field-group -dual -alpha">
               {{ Form::label('rec['.$i.'][first_name]', 'First Name: ') }}
               {{ Form::text('rec['.$i.'][first_name]', $recs[$i]['first_name']) }}
@@ -41,7 +78,7 @@
             {{-- Last Name --}}
             <div class="field-group -dual -beta">
               {{ Form::label('rec['.$i.'][last_name]', 'Last Name: ') }}
-              {{ Form::text('rec['.$i.'][last_name]', $recs[$i]['last_name']) }}
+              {{ Form::text('rec['.$i.'][last_name]', $recs[$i]['last_name'])  }}
               {{ errorsFor('rec['.$i.'][last_name]', $errors) }}
             </div>
 
@@ -65,6 +102,7 @@
               {{ Form::text('rec['.$i.'][relationship]', $recs[$i]['relationship']) }}
               {{ errorsFor('rec['.$i.'][relationship]', $errors) }}
             </div>
+
             @else
               {{-- First Name --}}
               <div class="field-group -dual -alpha">

--- a/resources/views/recommendation/applicant_edit.blade.php
+++ b/resources/views/recommendation/applicant_edit.blade.php
@@ -35,70 +35,70 @@
             <div class="field-group -dual -alpha">
               {{ Form::label('rec['.$i.'][first_name]', 'First Name: ') }}
               {{ Form::text('rec['.$i.'][first_name]', $recs[$i]['first_name']) }}
-              {{ errorsFor('rec['.$i.'][first_name]', $errors); }}
+              {{ errorsFor('rec['.$i.'][first_name]', $errors) }}
             </div>
 
             {{-- Last Name --}}
             <div class="field-group -dual -beta">
               {{ Form::label('rec['.$i.'][last_name]', 'Last Name: ') }}
               {{ Form::text('rec['.$i.'][last_name]', $recs[$i]['last_name']) }}
-              {{ errorsFor('rec['.$i.'][last_name]', $errors); }}
+              {{ errorsFor('rec['.$i.'][last_name]', $errors) }}
             </div>
 
             {{-- Email --}}
             <div class="field-group -dual -alpha">
               {{ Form::label('rec['.$i.'][email]', 'Email: ') }}
               {{ Form::email('rec['.$i.'][email]', $recs[$i]['email']) }}
-              {{ errorsFor('rec['.$i.'][email]', $errors); }}
+              {{ errorsFor('rec['.$i.'][email]', $errors) }}
             </div>
 
             {{-- Phone Number --}}
             <div class="field-group -dual -beta">
               {{ Form::label('rec['.$i.'][phone]', 'Phone Number: ') }}
               {{ Form::text('rec['.$i.'][phone]', $recs[$i]['phone']) }}
-              {{ errorsFor('rec['.$i.'][phone]', $errors); }}
+              {{ errorsFor('rec['.$i.'][phone]', $errors) }}
             </div>
 
              {{-- Relationship --}}
             <div class="field-group -mono">
               {{ Form::label('rec['.$i.'][relationship]', 'Relationship to you: ') }}
               {{ Form::text('rec['.$i.'][relationship]', $recs[$i]['relationship']) }}
-              {{ errorsFor('rec['.$i.'][relationship]', $errors); }}
+              {{ errorsFor('rec['.$i.'][relationship]', $errors) }}
             </div>
             @else
               {{-- First Name --}}
               <div class="field-group -dual -alpha">
                 {{ Form::label('rec['.$i.'][first_name]', 'First Name: ') }}
                 {{ Form::text('rec['.$i.'][first_name]') }}
-                {{ errorsFor('rec['.$i.'][first_name]', $errors); }}
+                {{ errorsFor('rec['.$i.'][first_name]', $errors) }}
               </div>
 
               {{-- Last Name --}}
               <div class="field-group -dual -beta">
                 {{ Form::label('rec['.$i.'][last_name]', 'Last Name: ') }}
                 {{ Form::text('rec['.$i.'][last_name]') }}
-                {{ errorsFor('rec['.$i.'][last_name]', $errors); }}
+                {{ errorsFor('rec['.$i.'][last_name]', $errors) }}
               </div>
 
               {{-- Email --}}
               <div class="field-group -dual -alpha">
                 {{ Form::label('rec['.$i.'][email]', 'Email: ') }}
                 {{ Form::email('rec['.$i.'][email]') }}
-                {{ errorsFor('rec['.$i.'][email]', $errors); }}
+                {{ errorsFor('rec['.$i.'][email]', $errors) }}
               </div>
 
               {{-- Phone Number --}}
               <div class="field-group -dual -beta">
                 {{ Form::label('rec['.$i.'][phone]', 'Phone Number: ') }}
                 {{ Form::text('rec['.$i.'][phone]') }}
-                {{ errorsFor('rec['.$i.'][phone]', $errors); }}
+                {{ errorsFor('rec['.$i.'][phone]', $errors) }}
               </div>
 
                {{-- Relationship --}}
               <div class="field-group -mono">
                 {{ Form::label('rec['.$i.'][relationship]', 'Relationship to you: ') }}
                 {{ Form::text('rec['.$i.'][relationship]') }}
-                {{ errorsFor('rec['.$i.'][relationship]', $errors); }}
+                {{ errorsFor('rec['.$i.'][relationship]', $errors) }}
               </div>
             @endif
 

--- a/resources/views/recommendation/applicant_edit.blade.php
+++ b/resources/views/recommendation/applicant_edit.blade.php
@@ -29,7 +29,7 @@
                 @endif
               </h2>
             @endif
-            @if (in_array($recs[$i]['id'], $complete_recs))
+            @if (in_array(isset($recs[$i]) && $recs[$i]['id'], $complete_recs))
             {{ Form::hidden('rec['.$i.'][id]', $recs[$i]['id']) }}
             {{-- First Name --}}
             <div class="field-group -dual -alpha">

--- a/resources/views/recommendation/applicant_edit.blade.php
+++ b/resources/views/recommendation/applicant_edit.blade.php
@@ -107,7 +107,7 @@
 
           {{-- Submit Button --}}
           <div class="field-group">
-            {{ Form::submit('Resend Request!', ['class' => 'button -default']) }}
+            {{ Form::submit('Update Requests!', ['class' => 'button -default']) }}
           </div>
 
         {{ Form::close() }}

--- a/resources/views/recommendation/applicant_edit.blade.php
+++ b/resources/views/recommendation/applicant_edit.blade.php
@@ -29,7 +29,7 @@
                 @endif
               </h2>
             @endif
-            @if (in_array(isset($recs[$i]) && $recs[$i]['id'], $complete_recs))
+            @if (isset($recs[$i]) && in_array($recs[$i]['id'], $complete_recs))
             {{ Form::hidden('rec['.$i.'][id]', $recs[$i]['id']) }}
             {{-- First Name --}}
             <div class="field-group -dual -alpha">

--- a/resources/views/recommendation/create.blade.php
+++ b/resources/views/recommendation/create.blade.php
@@ -33,7 +33,7 @@
               {!! Form::label('rec['.$i.'][first_name]', 'First Name: ') !!}
               {!! Form::text('rec['.$i.'][first_name]') !!}
               {{-- @TODO: will need a different method of showing errors, since these fields are dynamic and we can't use the ValidationService --}}
-              {!! errorsFor('rec['.$i.'][first_name]', $errors); !!}
+              {!! errorsFor('rec['.$i.'][first_name]', $errors) !!}
             </div>
 
             {{-- Last Name --}}
@@ -41,7 +41,7 @@
               {!! Form::label('rec['.$i.'][last_name]', 'Last Name: ') !!}
               {!! Form::text('rec['.$i.'][last_name]') !!}
               {{-- @TODO: will need a different method of showing errors, since these fields are dynamic and we can't use the ValidationService --}}
-              {!! errorsFor('rec['.$i.'][last_name]', $errors); !!}
+              {!! errorsFor('rec['.$i.'][last_name]', $errors) !!}
             </div>
 
             {{-- Email --}}
@@ -49,7 +49,7 @@
               {!! Form::label('rec['.$i.'][email]', 'Email: ') !!}
               {!! Form::email('rec['.$i.'][email]') !!}
               {{-- @TODO: will need a different method of showing errors, since these fields are dynamic and we can't use the ValidationService --}}
-              {!! errorsFor('rec['.$i.'][email]', $errors); !!}
+              {!! errorsFor('rec['.$i.'][email]', $errors) !!}
             </div>
 
             {{-- Phone Number --}}
@@ -57,14 +57,14 @@
               {!! Form::label('rec['.$i.'][phone]', 'Phone Number: ') !!}
               {!! Form::text('rec['.$i.'][phone]') !!}
               {{-- @TODO: will need a different method of showing errors, since these fields are dynamic and we can't use the ValidationService --}}
-              {!! errorsFor('rec['.$i.'][phone]', $errors); !!}
+              {!! errorsFor('rec['.$i.'][phone]', $errors) !!}
             </div>
 
              {{-- Relationship --}}
             <div class="field-group -mono">
               {!! Form::label('rec['.$i.'][relationship]', 'Relationship to you: ') !!}
               {!! Form::text('rec['.$i.'][relationship]') !!}
-              {!! errorsFor('rec['.$i.'][relationship]', $errors); !!}
+              {!! errorsFor('rec['.$i.'][relationship]', $errors) !!}
             </div>
           @endfor
 

--- a/resources/views/recommendation/edit.blade.php
+++ b/resources/views/recommendation/edit.blade.php
@@ -9,34 +9,35 @@
     <div class="segment -compact">
       <div class="wrapper">
 
+      @if(isset($rank_values))
         {{-- This will be seen by the recommender --}}
         <p>Please fill all fields with information regarding the applicant.</p>
 
         @if (isset($vars->recommendation_update_help_text))
           <p>{{ $vars->recommendation_update_help_text }}</p>
         @endif
-
+      @endif
 
         {!! Form::model($recommendation, ['method' => 'PATCH', 'route' => ['recommendation.update', $recommendation->id]]) !!}
 
           {{-- First Name --}}
           <div class="field-group -dual -alpha">
             {!! Form::label('first_name', 'Your First Name: ') !!}
-            {!! Form::text('first_name', $recommendation->first_name, array('disabled')) !!}
+            {!! Form::text('first_name', $recommendation->first_name) !!}
             {!! errorsFor('first_name', $errors); !!}
           </div>
 
           {{-- Last Name --}}
           <div class="field-group -dual -beta">
             {!! Form::label('last_name', 'Your Last Name: ') !!}
-            {!! Form::text('last_name', $recommendation->last_name, array('disabled'))  !!}
+            {!! Form::text('last_name', $recommendation->last_name) !!}
             {!! errorsFor('last_name', $errors); !!}
           </div>
 
           {{-- Email --}}
           <div class="field-group -dual -alpha">
             {!! Form::label('email', 'Your Email: ') !!}
-            {!! Form::email('email', $recommendation->email, array('disabled')) !!}
+            {!! Form::email('email', $recommendation->email) !!}
             {!! errorsFor('email', $errors); !!}
           </div>
 
@@ -44,9 +45,10 @@
           <div class="field-group -dual -beta">
             {!! Form::label('phone', 'Your Phone Number: ') !!}
             {!! Form::text('phone') !!}
-            {!! errorsFor('phone', $errors); !!}
+            {!! errorsFor('phone', $errors) !!}
           </div>
 
+        @if(isset($rank_values))
           {{-- Rank Character --}}
           <div class="field-group">
             {!! Form::label('rank_character', $scholarship->label_rec_rank_character) !!}
@@ -77,12 +79,15 @@
           </div>
           @endif
 
-
-
-
           {{-- Submit Button --}}
           <div class="field-group">
             {!! Form::submit('Submit Recommendation', ['class' => 'button -default']) !!}
+          </div>
+        @endif
+
+          {{-- Submit Button --}}
+          <div class="field-group">
+            {!! Form::submit('Update Recommendation', ['class' => 'button -default']) !!}
           </div>
 
         {!! Form::close() !!}

--- a/resources/views/recommendation/edit.blade.php
+++ b/resources/views/recommendation/edit.blade.php
@@ -85,11 +85,6 @@
           </div>
         @endif
 
-          {{-- Submit Button --}}
-          <div class="field-group">
-            {!! Form::submit('Update Recommendation', ['class' => 'button -default']) !!}
-          </div>
-
         {!! Form::close() !!}
 
       </div>

--- a/resources/views/recommendation/edit.blade.php
+++ b/resources/views/recommendation/edit.blade.php
@@ -20,6 +20,7 @@
 
         {!! Form::model($recommendation, ['method' => 'PATCH', 'route' => ['recommendation.update', $recommendation->id]]) !!}
 
+        <div class="clearfix">
           {{-- First Name --}}
           <div class="field-group -dual -alpha">
             {!! Form::label('first_name', 'Your First Name: ') !!}
@@ -33,7 +34,9 @@
             {!! Form::text('last_name', $recommendation->last_name) !!}
             {!! errorsFor('last_name', $errors); !!}
           </div>
+        </div>
 
+        <div class="clearfix">
           {{-- Email --}}
           <div class="field-group -dual -alpha">
             {!! Form::label('email', 'Your Email: ') !!}
@@ -47,6 +50,7 @@
             {!! Form::text('phone') !!}
             {!! errorsFor('phone', $errors) !!}
           </div>
+        </div>
 
         @if(isset($rank_values))
           {{-- Rank Character --}}

--- a/resources/views/status/index.blade.php
+++ b/resources/views/status/index.blade.php
@@ -72,7 +72,6 @@
 
                 @if ($rec['complete'] !== 'Recommendation received!' && !$closed)
                   {!! '<a class="button -link" href="' . URL::route('resend', array('id' => $rec['id'])) . '">Resend<span class="icon icon-send"></span></a>' !!}
-                  {!! '<a class="button -link" href="' . URL::route('recommendation.edit', array('id' => $rec['id'])) . '">Edit<span class="icon icon-edit"></span></a>' !!}
                 @endif
               </li>
             @endforeach

--- a/resources/views/status/index.blade.php
+++ b/resources/views/status/index.blade.php
@@ -59,9 +59,9 @@
           <ul class="media-list media-list--status">
             @foreach($recommendations as $index => $rec)
               @if($rec['complete'] !== 'Recommendation received!')
-              <li class="-incomplete">
+                <li class="-incomplete">
               @else
-              <li class="complete">
+                <li class="complete">
               @endif
                 <span class="icon icon-status" data-icon="&#x2713"></span>Recommendation
                 <ul>
@@ -72,6 +72,7 @@
 
                 @if ($rec['complete'] !== 'Recommendation received!' && !$closed)
                   {!! '<a class="button -link" href="' . URL::route('resend', array('id' => $rec['id'])) . '">Resend<span class="icon icon-send"></span></a>' !!}
+                  {!! '<a class="button -link" href="' . URL::route('recommendation.edit', array('id' => $rec['id'])) . '">Edit<span class="icon icon-edit"></span></a>' !!}
                 @endif
               </li>
             @endforeach


### PR DESCRIPTION
Enter the joyous world of recommendations!

StyleCI fix PR to follow after I wrap up my branches in progress, otherwise there will be one million conflicts

Important changes:
- "Add a rec" button on status page is now "add or edit a rec"
- Applicant rec edit page allows them to edit existing recs that have not been completed and request new recs
- If an applicant edits an existing rec request email address, a new email is sent. Otherwise, no new email is sent.
- Recommenders can edit their name, email, and phone number on the recommendation page

### Issues:
Fixes #745
Fixes #750