### PR TITLE
Custom fonts

### DIFF
--- a/app/Http/Controllers/admin/SettingsController.php
+++ b/app/Http/Controllers/admin/SettingsController.php
@@ -90,7 +90,7 @@ class SettingsController extends \Controller
       'cap_color',
       'cap_color_contrast',
       'custom_font_kit_id',
-      'custom_font_name'
+      'custom_font_name',
       ]);
 
       $input = $this->settings->nullify($input);

--- a/app/Http/Controllers/admin/SettingsController.php
+++ b/app/Http/Controllers/admin/SettingsController.php
@@ -80,7 +80,7 @@ class SettingsController extends \Controller
   {
       $this->validate($request, $this->rules);
 
-      $input = Input::only(
+      $input = $request->only([
       'primary_color',
       'primary_color_contrast',
       'primary_color_interaction',
@@ -91,7 +91,7 @@ class SettingsController extends \Controller
       'cap_color_contrast',
       'custom_font_embed',
       'custom_font_name'
-      );
+      ]);
 
       $input = $this->settings->nullify($input);
 

--- a/app/Http/Controllers/admin/SettingsController.php
+++ b/app/Http/Controllers/admin/SettingsController.php
@@ -80,7 +80,7 @@ class SettingsController extends \Controller
   {
       $this->validate($request, $this->rules);
 
-      $input = Reqeust::only(
+      $input = Input::only(
       'primary_color',
       'primary_color_contrast',
       'primary_color_interaction',
@@ -88,7 +88,9 @@ class SettingsController extends \Controller
       'secondary_color_contrast',
       'secondary_color_interaction',
       'cap_color',
-      'cap_color_contrast'
+      'cap_color_contrast',
+      'custom_font_embed',
+      'custom_font_name'
       );
 
       $input = $this->settings->nullify($input);
@@ -105,7 +107,7 @@ class SettingsController extends \Controller
     // Create the custom stylesheet file from values in Appearance settings.
     createCustomStylesheet($input);
 
-      return redirect('appearance.edit')->with('flash_message', ['text' => 'Success: Appearance settings have been saved!', 'class' => 'alert-success']);
+      return redirect()->route('appearance.edit')->with('flash_message', ['text' => 'Success: Appearance settings have been saved!', 'class' => 'alert-success']);
   }
 
   /**

--- a/app/Http/Controllers/admin/SettingsController.php
+++ b/app/Http/Controllers/admin/SettingsController.php
@@ -89,7 +89,7 @@ class SettingsController extends \Controller
       'secondary_color_interaction',
       'cap_color',
       'cap_color_contrast',
-      'custom_font_embed',
+      'custom_font_kit_id',
       'custom_font_name'
       ]);
 

--- a/app/Scholarship/Repositories/SettingRepository.php
+++ b/app/Scholarship/Repositories/SettingRepository.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Input;
 
 class SettingRepository
 {
-    public static $pageQueryItems = ['company_name', 'company_url', 'site_name', 'site_url', 'header_logo', 'footer_logo', 'footer_text', 'tracking_code_id', 'official_rules_url', 'background_image', 'custom_font_embed', 'custom_font_name'];
+    public static $pageQueryItems = ['company_name', 'company_url', 'site_name', 'site_url', 'header_logo', 'footer_logo', 'footer_text', 'tracking_code_id', 'official_rules_url', 'background_image', 'custom_font_kit_id', 'custom_font_name'];
 
     public static $openGraphDataQueryItems = ['open_graph_data_title', 'open_graph_data_description', 'open_graph_data_type', 'open_graph_data_url', 'open_graph_data_image'];
 

--- a/app/Scholarship/Repositories/SettingRepository.php
+++ b/app/Scholarship/Repositories/SettingRepository.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Input;
 
 class SettingRepository
 {
-    public static $pageQueryItems = ['company_name', 'company_url', 'site_name', 'site_url', 'header_logo', 'footer_logo', 'footer_text', 'tracking_code_id', 'official_rules_url', 'background_image'];
+    public static $pageQueryItems = ['company_name', 'company_url', 'site_name', 'site_url', 'header_logo', 'footer_logo', 'footer_text', 'tracking_code_id', 'official_rules_url', 'background_image', 'custom_font_embed', 'custom_font_name'];
 
     public static $openGraphDataQueryItems = ['open_graph_data_title', 'open_graph_data_description', 'open_graph_data_type', 'open_graph_data_url', 'open_graph_data_image'];
 

--- a/database/seeds/SettingsTableSeeder.php
+++ b/database/seeds/SettingsTableSeeder.php
@@ -105,9 +105,9 @@ class SettingsTableSeeder extends Seeder
 
         Setting::create([
           'category'  => 'appearance',
-          'key'       => 'custom_font_embed',
+          'key'       => 'custom_font_kit_id',
           'value'     => '',
-          'type'      => 'textarea',
+          'type'      => 'text',
         ]);
 
         Setting::create([

--- a/database/seeds/SettingsTableSeeder.php
+++ b/database/seeds/SettingsTableSeeder.php
@@ -102,5 +102,19 @@ class SettingsTableSeeder extends Seeder
           'value'     => '',
           'type'      => 'image',
         ]);
+
+        Setting::create([
+          'category'  => 'appearance',
+          'key'       => 'custom_font_embed',
+          'value'     => '',
+          'type'      => 'textarea',
+        ]);
+
+        Setting::create([
+          'category'  => 'appearance',
+          'key'       => 'custom_font_name',
+          'value'     => '',
+          'type'      => 'text',
+        ]);
     }
 }

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -6,8 +6,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    @if (isset($global_vars->custom_font_embed) || isset($global_vars->custom_font_name))
-      {!! $global_vars->custom_font_embed !!}
+    @if (isset($global_vars->custom_font_kit_id) || isset($global_vars->custom_font_name))
+      <script src="https://use.typekit.net/{{ $global_vars->custom_font_kit_id }}.js"></script>
+      <script>try{Typekit.load({ async: true });}catch(e){}</script>
       <style type="text/css"> * { font-family: "{{ $global_vars->custom_font_name }}"; } .heading { font-family: "{{ $global_vars->custom_font_name }}" !IMPORTANT; font-weight:700 !IMPORTANT;}</style>
     @endif
 

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -6,6 +6,11 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    @if (isset($global_vars->custom_font_embed) || isset($global_vars->custom_font_name))
+      {!! $global_vars->custom_font_embed !!}
+      <style type="text/css"> * { font-family: "{{ $global_vars->custom_font_name }}"; } .heading { font-family: "{{ $global_vars->custom_font_name }}" !IMPORTANT; font-weight:700 !IMPORTANT;}</style>
+    @endif
+
 
     <title>{{ isset($page) ? $page->title . ' | ' : '' }}{{ $global_vars->site_name or 'Scholarship Application' }}</title>
 

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -9,7 +9,7 @@
     @if (isset($global_vars->custom_font_kit_id) || isset($global_vars->custom_font_name))
       <script src="https://use.typekit.net/{{ $global_vars->custom_font_kit_id }}.js"></script>
       <script>try{Typekit.load({ async: true });}catch(e){}</script>
-      <style type="text/css"> body { font-family: "{{ $global_vars->custom_font_name }}"; } .heading { font-family: "{{ $global_vars->custom_font_name }}" !IMPORTANT; font-weight:700 !IMPORTANT;}</style>
+      <style type="text/css"> body { font-family: "{{ $global_vars->custom_font_name }}" !IMPORTANT; } .heading { font-family: "{{ $global_vars->custom_font_name }}" !IMPORTANT; font-weight:700 !IMPORTANT;}</style>
     @endif
 
 

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -9,7 +9,7 @@
     @if (isset($global_vars->custom_font_kit_id) || isset($global_vars->custom_font_name))
       <script src="https://use.typekit.net/{{ $global_vars->custom_font_kit_id }}.js"></script>
       <script>try{Typekit.load({ async: true });}catch(e){}</script>
-      <style type="text/css"> * { font-family: "{{ $global_vars->custom_font_name }}"; } .heading { font-family: "{{ $global_vars->custom_font_name }}" !IMPORTANT; font-weight:700 !IMPORTANT;}</style>
+      <style type="text/css"> body { font-family: "{{ $global_vars->custom_font_name }}"; } .heading { font-family: "{{ $global_vars->custom_font_name }}" !IMPORTANT; font-weight:700 !IMPORTANT;}</style>
     @endif
 
 

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -29,7 +29,7 @@
     @endif
   </head>
 
-    @if (isset($global_vars->background_image))
+    @if ($global_vars->background_image)
       <body class="{{ bodyClass() }}" background="{{ $global_vars->background_image }}">
     @else
       <body class="{{ bodyClass() }}">

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -29,7 +29,7 @@
     @endif
   </head>
 
-    @if ($global_vars->background_image)
+    @if (isset($global_vars->background_image))
       <body class="{{ bodyClass() }}" background="{{ $global_vars->background_image }}">
     @else
       <body class="{{ bodyClass() }}">


### PR DESCRIPTION
- add new setting to allow admins to input the embed code and font name from Typekit
- updates to master template to change the fonts if they're there
- I used `!IMPORTANT` on the headers because they weren't updating otherwise, let me know if there is a better way
- add db seed for the new settings
- I dug around and couldn't find where in Typekit I could set the name of the font, so currently admins have to input that as well

For review: dream team of @weerd & @DFurnes 🏀 

Fixes #754 