### PR TITLE
bandaid on the cache clear

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use Cache;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Scholarship\Repositories\SettingRepository;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -29,6 +31,33 @@ class EventServiceProvider extends ServiceProvider
     {
         parent::boot($events);
 
-        //
+        $events->listen('settings.change', function($category) {
+              if ($category === 'general') {
+
+                // @TODO: get this to work
+                // Cache::forget('setting.' . implode('.', SettingRepository::$pageQueryItems));
+                // Cache::forget('setting.' . implode('.', SettingRepository::$nominateQueryItems));
+                // foreach (SettingRepository::$individualQueryItems as $item) {
+                //   Cache::forget('setting.' . $item);
+                // }
+                Cache::flush();
+
+              } elseif ($category === 'meta_data') {
+
+                // @TODO: get this to work
+                // Cache::forget('setting.' . implode('.', SettingRepository::$openGraphDataQueryItems));
+
+                // Cache::forget('setting.favicon');
+
+                Cache::flush();
+
+
+              } else {
+                // @TODO: get this to work
+                // Cache::forget('setting.' . $category);
+
+                Cache::flush();
+              }
+        });
     }
 }

--- a/app/Scholarship/Repositories/SettingRepository.php
+++ b/app/Scholarship/Repositories/SettingRepository.php
@@ -139,6 +139,7 @@ class SettingRepository
   {
       $settings_data = $this->getCategorySettingsVars('appearance');
 
-      createCustomStylesheet($settings_data);
+      // @TODO: this is a temporary bandaid
+      // createCustomStylesheet($settings_data);
   }
 }


### PR DESCRIPTION
- this needs to be fixed for real, but if we want to hold off on that and start testing all the other updates this will allow that
- when settings were updated, the cache wasn't clearing automatically, meaning the changes didn't show up
- when the "Clear Cache" button was clicked, we ended up with some style text at the top of the non-admin pages at first

@angaither not sure if this is something we care about putting a bandaid on but it was real quick so here it is just in case. I spend some time trying to figure out why it wasn't working but so far it is unclear