### PR TITLE
access scholarship variable correctly in homepage

### DIFF
--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -17,7 +17,7 @@
     @endforeach
 
     {{-- Only include nomination form if still open. --}}
-    @if(!App\Models\Scholarship::isClosed('nomination') && App\Models\Scholarship::isOpen())
+    @if($scholarship->isOpen('nomination') && $scholarship->isOpen())
       @include('pages.partials._nomination-form')
     @endif
 

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -17,7 +17,7 @@
     @endforeach
 
     {{-- Only include nomination form if still open. --}}
-    @if($scholarship->isOpen('nomination') && $scholarship->isOpen())
+    @if(!$scholarship->isClosed('nomination') && $scholarship->isOpen())
       @include('pages.partials._nomination-form')
     @endif
 


### PR DESCRIPTION
```
FatalErrorException in ae334a78cf7b8e3ba140772f80c69499f5c7db4d.php line 15:
Class 'Scholarship' not found
```

- this should fix the error on the whitelabel homepage