### PR TITLE
change first name, last name, relationship validation to allow spaces

### DIFF
--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -14,8 +14,8 @@ class RecommendationController extends \Controller
     protected $settings;
 
     protected $rules = [
-      'first_name'      => 'alpha|required',
-      'last_name'       => 'alpha|required',
+      'first_name'      => 'required',
+      'last_name'       => 'required',
       'phone'           => 'numeric|required',
       'email'           => 'email|required',
     ];
@@ -27,7 +27,7 @@ class RecommendationController extends \Controller
     ];
 
     protected $applicant_rules = [
-      'relationship'    => 'alpha|required',
+      'relationship'    => 'required',
     ];
 
     protected $messages = [


### PR DESCRIPTION
- alpha validation does not allow spaces, which we probably do want to allow in these three fields, so I changed these fields to just be required
- this is consistent with how we validate first and last names for users