### PR TITLE
maybe we need a name?

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ SESSION_DRIVER=file
 QUEUE_DRIVER=sync
 
 MAIL_DRIVER=mandrill
-MAIL_HOST=mailtrap.io
+MAIL_HOST=smtp.mailgun.org
 MAIL_PORT=587
 MAIL_USERNAME=example@example.com
 MAIL_PASSWORD=null

--- a/config/mail.php
+++ b/config/mail.php
@@ -54,7 +54,7 @@ return [
     |
     */
 
-    'from' => ['address' => env('MAIL_USERNAME', null), 'name' => null],
+    'from' => ['address' => env('EMAIL_ADDRESS'), 'name' => env('EMAIL_NAME')],
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
- Many sources say the error we were getting was because we didn't have a default email address, but the email error was still happening after one was added. Maybe it says the same thing about a blank name?

- Also, the mail host was incorrect.

This is the error:
```
Swift_RfcComplianceException in MailboxHeader.php line 348:
Address in mailbox given [] does not comply with RFC 2822, 3.6.2.
```