### PR TITLE
fixes edit button crashes and rethink that button

### DIFF
--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -216,7 +216,7 @@ class AdminController extends \Controller
 
         // Get what races should be checked and pass to the view
         $user_races = [];
-        if ($profile) {
+        if (!is_null($profile)) {
           $currentRaces = Profile::getUserRace($profile->id);
           foreach ($currentRaces as $currentRace) {
               $user_races[] = $currentRace['race'];

--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -206,7 +206,7 @@ class AdminController extends \Controller
     {
         $application = Application::getUserApplication($id);
         $user_info = User::getUserInfo($id);
-        $profile = Profile::with('race')->whereUserId($id)->firstOrFail();
+        $profile = Profile::with('race')->whereUserId($id)->first();
         if (isset($application)) {
             $label = Scholarship::getScholarshipLabels($application['scholarship_id']);
         }
@@ -215,10 +215,12 @@ class AdminController extends \Controller
         $states = Profile::getStates();
 
         // Get what races should be checked and pass to the view
-        $currentRaces = Profile::getUserRace($profile->id);
         $user_races = [];
-        foreach ($currentRaces as $currentRace) {
-            $user_races[] = $currentRace['race'];
+        if ($profile) {
+          $currentRaces = Profile::getUserRace($profile->id);
+          foreach ($currentRaces as $currentRace) {
+              $user_races[] = $currentRace['race'];
+          }
         }
 
         $hear_about = Scholarship::getCurrentScholarship()->hear_about_options;

--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -217,10 +217,10 @@ class AdminController extends \Controller
         // Get what races should be checked and pass to the view
         $user_races = [];
         if (!is_null($profile)) {
-          $currentRaces = Profile::getUserRace($profile->id);
-          foreach ($currentRaces as $currentRace) {
-              $user_races[] = $currentRace['race'];
-          }
+            $currentRaces = Profile::getUserRace($profile->id);
+            foreach ($currentRaces as $currentRace) {
+                $user_races[] = $currentRace['race'];
+            }
         }
 
         $hear_about = Scholarship::getCurrentScholarship()->hear_about_options;

--- a/resources/views/admin/applications/edit.blade.php
+++ b/resources/views/admin/applications/edit.blade.php
@@ -14,6 +14,7 @@
 
           <hr>
 
+        @if (!is_null($profile))
           <h2> Profile </h2>
           <div class="well well-lg">
           {!! Form::model($user, ['method' => 'PATCH', 'route' => ['profile.update', $id]]) !!}
@@ -21,6 +22,7 @@
             {!! Form::submit('Update info', ['class' => 'btn btn-primary', 'name' => 'complete']) !!}
           {!! Form::close() !!}
          </div>
+        @endif
 
         @if (!is_null($application))
           <h2>Application</h2>

--- a/resources/views/admin/applications/show.blade.php
+++ b/resources/views/admin/applications/show.blade.php
@@ -11,8 +11,10 @@
 
         <div class="wrapper">
           <p>{{ strtolower($user['email']) }}</p>
-          {!! '<a class="btn btn-default btn-edit" href="' . URL::route('admin.application.edit', array('id' => $id)) . '"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit</a>' !!}
 
+          @if (isset($profile) || !is_null($application) || (!is_null($recommendations) && count($recommendations) > 0))
+            {!! '<a class="btn btn-default btn-edit" href="' . URL::route('admin.application.edit', array('id' => $id)) . '"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit</a>' !!}
+          @endif
           <hr>
 
           @if ($show_rating)


### PR DESCRIPTION
#### What's this PR do?
- We do not want to crash if a profile is not found, because that is a real case that can happen.
- Instead, let the profile be null and just make sure it's not before using it.
- Maybe it makes sense to only show the edit button if there is something editable (profile, application, or recommendations) being displayed for the applicant. I included that change. We can unchange it if we want.

#### How should this be reviewed?
- Login as an admin. 
- Go to an application that only has a registration (aka they created an account but did not fill out Basic Info). Make sure there is no edit button. 
- Go to applications that have all kinds of combinations of profiles, applications, and recs. Make sure the edit button shows up when it should and that nothing crashes when you click on it.

#### Relevant tickets
Fixes #817

#### Checklist
- [ ] Tested on Whitelabel.
