### PR TITLE
flash message 

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -39,7 +39,7 @@ class Authenticate
             if ($request->ajax()) {
                 return response('Unauthorized.', 401);
             } else {
-                return redirect()->home();
+                return redirect()->home()->with('flash_message', ['text' => 'You must be logged in to access that page.', 'class' => '-warning']);
             }
         }
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -22,7 +22,7 @@ Route::resource('profile', 'ProfilesController');
 // Application
 Route::resource('application', 'ApplicationController', ['middleware' => 'auth']);
 // Status
-Route::get('status', ['as' => 'status', 'uses' => 'StatusController@status', 'middleware' => 'auth']);
+Route::get('status', ['as' => 'status', 'uses' => 'StatusController@status'])->middleware(['auth']);
 // this should be a post.
 Route::get('resend-email', ['as' => 'resend', 'uses' => 'StatusController@resendEmailRequest']);
 // Review


### PR DESCRIPTION
#### What's this PR do?
If a user tries to go to the status page but isn't logged in (or anything else that causes the auth middleware to kick in), they are redirected to the homepage WITH flash messaging 💥 

#### How should this be reviewed?
On Whitelabel, click "continue an application" or go to `/status` and make sure you end up on the homepage with this message:
![image](https://cloud.githubusercontent.com/assets/4240292/16807965/8788adc4-48e8-11e6-99e4-5d7d5e2956e6.png)



#### Any background context you want to provide?
I couldn't get this to work for a while and I thiiiiiink it was fixed by the change to the routes file?

#### Relevant tickets
Fixes #820

#### Checklist
- [ ] Tested on Whitelabel.

