### PR TITLE
Admin redirect

### DIFF
--- a/app/Http/Controllers/SessionsController.php
+++ b/app/Http/Controllers/SessionsController.php
@@ -42,7 +42,6 @@ class SessionsController extends \Controller
       $input = $request->only('email', 'password');
 
       if (Auth::attempt($input)) {
-
           if (Auth::user()->hasRole('administrator')) {
               return Redirect::route('admin');
           }

--- a/app/Http/Controllers/SessionsController.php
+++ b/app/Http/Controllers/SessionsController.php
@@ -43,9 +43,9 @@ class SessionsController extends \Controller
 
       if (Auth::attempt($input)) {
 
-          // if (Auth::user()->hasRole('administrator')) {
-          //     return Redirect::route('admin');
-          // }
+          if (Auth::user()->hasRole('administrator')) {
+              return Redirect::route('admin');
+          }
 
           return redirect()->intended('status')->with('flash_message', ['text' => 'You have been logged in!', 'class' => '-info']);
       }


### PR DESCRIPTION
#### What's this PR do?
If you login and you're an admin you get directed to `/admin` instead of `/status`.

#### How should this be reviewed?
Login as an admin and make sure you get redirected to `/admin`. Login as a plebian and make sure you still get redirected to `/status`.

#### Any background context you want to provide?
I'm sure I commented this out for a good reason 😬 , but whatever it was is not longer valid.

#### Checklist
- [ ] Tested on Whitelabel.

