### PR TITLE
add missing models to nomination controller

### DIFF
--- a/app/Http/Controllers/NominationController.php
+++ b/app/Http/Controllers/NominationController.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Email;
+use App\Models\Nomination;
 use Illuminate\Http\Request;
 use Scholarship\Forms\NominationForm;
 


### PR DESCRIPTION
#### What's this PR do?
The `NominationController` was missing the models it uses. This adds them in!

#### How should this be reviewed?
Make sure you are able to send a nomination from the block on the homepage. If the block isn't showing up, check the timing of the scholarship and change it so that it does show up (aka start date is before today, nom end date is after today).

#### Relevant tickets
Fixes this:

![image](https://cloud.githubusercontent.com/assets/4240292/18517495/7d9caf96-7a6a-11e6-8352-814699392f78.png)


#### Checklist
- [ ] Tested on Whitelabel.

