### PR TITLE
allow us to use html in the footer

### DIFF
--- a/resources/views/layouts/partials/footer.blade.php
+++ b/resources/views/layouts/partials/footer.blade.php
@@ -10,7 +10,7 @@
     @if (isset($global_vars->footer_text) || isset($global_vars->official_rules_url))
     <p class="__message">
       <small>
-        {{ $global_vars->footer_text or '' }}
+        {!! $global_vars->footer_text or '' !!}
 
         @if (isset($global_vars->official_rules_url))
           Check out the {{ link_to($global_vars->official_rules_url, 'Official Rules', ['target' => '_blank']) }}.


### PR DESCRIPTION
#### What's this PR do?
Don't escape the HTML in the footer text because we want to use it.

#### How should this be reviewed?
1. Put HTML in the "Footer text" field at `/admin/settings/general`.
2. Go look at the footer.
3. See your text formatted properly.

#### Any background context you want to provide?
Yet again! These are hard to catch because they don't always show up locally and especially don't show up locally if you aren't trying to use markdown in that field!

#### Relevant tickets
Fixes #836

#### Checklist
- [ ] Tested on Whitelabel.

