### PR TITLE
fixing the slideshow of winners

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,4 +24,5 @@ elixir(function(mix) {
 	mix.copy('resources/assets/bower_components/bootstrap/dist/js', 'public/dist/js');
 	mix.copy('resources/assets/bower_components/bootstrap/dist/css', 'public/dist/css');
 	mix.copy('resources/assets/js/libs', 'public/dist/js');
+	mix.browserify('main.js', 'public/dist/js/main.js');
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "jquery": "global:$"
   },
   "dependencies": {
+    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-react": "^6.11.1",
     "susy": "^2.2.2"
   },
   "devDependencies": {

--- a/resources/assets/js/slideshow.js
+++ b/resources/assets/js/slideshow.js
@@ -94,7 +94,7 @@ Slideshow.prototype.show = function (slideIndex) {
     }
   }
 
-  $selectedSlide = $(_$slides.get(slideIndex));
+  const $selectedSlide = $(_$slides.get(slideIndex));
   classToggle($selectedSlide, 'is-pending');
   classToggle($selectedSlide, 'is-viewing');
 

--- a/resources/assets/js/slideshow.js
+++ b/resources/assets/js/slideshow.js
@@ -87,7 +87,7 @@ Slideshow.prototype.show = function (slideIndex) {
   var _$slides = this.$slides;
 
   if (slideIndex > 0) {
-    for (i = 0; i < slideIndex; i++) {
+    for (var i = 0; i < slideIndex; i++) {
       var $thisSlide = $(_$slides[i]);
       classToggle($thisSlide, 'is-pending');
       classToggle($thisSlide, 'is-completed');
@@ -127,7 +127,7 @@ Slideshow.prototype.move = function (direction) {
 Slideshow.prototype.reset = function () {
 
   this.$slides.each(function () {
-    $slide = $(this);
+    const $slide = $(this);
 
     if ($slide.hasClass('is-completed') || $slide.hasClass('is-viewing')) {
       if ($slide.hasClass('is-completed')) {


### PR DESCRIPTION
#### What's this PR do?
- Browserifies our javascript! 
- Adds new dependencies to `package.json` in order to resolve errors when browerifying.
- Puts `const` or `var` before a couple of variables in `slideshow.js` so it works and so we don't get any errors about things being undefined

#### How should this be reviewed?
Make sure the winner gallery slideshow works! You should be able to click on any tile to start and then go back and forth through all of them.

#### Relevant tickets
Fixes #839

#### Checklist
- [ ] Tested on Whitelabel.
