### PR TITLE
get the rec token correctly and use consistent email tokens

### DIFF
--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -385,7 +385,7 @@ class AdminController extends \Controller
         // get rec info
       $rec_id = Input::get('rec_id');
         $recommendation = Recommendation::whereId($rec_id)->firstOrFail();
-        $token = RecommendationToken::where('recommendation_id', $recommendation->id);
+        $token = RecommendationToken::where('recommendation_id', $recommendation->id)->first()->token;
         $link = link_to_route('recommendation.edit', 'Please provide a recommendation', [$recommendation->id, 'token' => $token]);
 
       // get applicant info
@@ -395,8 +395,8 @@ class AdminController extends \Controller
       // build and send email
       $email = new Email();
         $data = [
-        ':link:'           => $link,
-        ':applicant_name:' => $applicant->first_name.' '.$applicant->last_name,
+        'link'           => $link,
+        'applicant_name' => $applicant->first_name.' '.$applicant->last_name,
       ];
         $email->sendEmail('request', 'recommender', $recommendation->email, $data);
 


### PR DESCRIPTION
#### What's this PR do?
When admins re-sent rec emails:
1. The recommendation token wasn't being grabbed properly and now it is.
2. The tokens were not consistent with the other tokens for the same email.

#### How should this be reviewed?
Does it make sense to do it this way? Open to suggestions. 

#### Checklist
- [ ] Tested on Whitelabel.

