### PR TITLE
Fix mass rec creation

### DIFF
--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -94,7 +94,7 @@ class RecommendationController extends \Controller
       if ($errors !== []) {
           $errorMessage = $this->formatErrors($errors);
 
-          return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
+          return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'.$errorMessage, 'class' => '-error']);
       } else {
           // Once there are no errors, go through the filled in rec forms and create the recs
           foreach ($recs as $key => $rec) {
@@ -109,7 +109,7 @@ class RecommendationController extends \Controller
                   $token = $recommendation->generateRecToken($recommendation);
                   $this->prepareRecRequestConfirmationEmail($recommendation);
                   $this->prepareRecRequestEmail($recommendation, $token);
-            }
+              }
           }
       }
 
@@ -275,7 +275,7 @@ class RecommendationController extends \Controller
             if ($errors !== []) {
                 $errorMessage = $this->formatErrors($errors);
 
-                return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
+                return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'.$errorMessage, 'class' => '-error']);
             } else {
                 // Update the rec if there are no errors
               $currentRec = Recommendation::whereId($rec['id'])->firstOrFail();
@@ -300,7 +300,7 @@ class RecommendationController extends \Controller
                   if ($errors !== []) {
                       $errorMessage = $this->formatErrors($errors);
 
-                      return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
+                      return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'.$errorMessage, 'class' => '-error']);
                   } else {
                       // If no errors, save the new rec
                       $newRec = new Recommendation();

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -127,6 +127,7 @@ class RecommendationController extends \Controller
   {
       $formatted = '';
 
+      // Go through the errors for each rec and format properly
       foreach ($errors as $recNumber => $errorArray) {
           $formatted .= 'Recommendation # '.($recNumber + 1).': <br>';
           $formatted .= '<ul>';

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -112,9 +112,17 @@ class RecommendationController extends \Controller
             }
           }
       }
+
       return redirect()->route('status')->with('flash_message', ['text' => 'Your recommendation request has been submitted!', 'class' => '-success']);
   }
 
+  /**
+   * Formats validation errors from the rec request form and returns a formatted string
+   *
+   * @param  array  $errors
+   *
+   * @return string $formatted
+   */
   public function formatErrors($errors)
   {
     $formatted = '';

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -79,36 +79,36 @@ class RecommendationController extends \Controller
       $errors = [];
 
       // Go through each rec and collect the validation errors
-      foreach ($recs as $key=>$rec) {
-        // Only try to validate and fill in recs that have any part of the form filled out
+      foreach ($recs as $key => $rec) {
+          // Only try to validate and fill in recs that have any part of the form filled out
         if (array_filter($rec)) {
             $v = Validator::make($rec, $rules);
 
             if ($v->fails()) {
-              $errors[$key] = $v->errors()->all();
+                $errors[$key] = $v->errors()->all();
             }
-          }
+        }
       }
 
       // If there are any errors in the form, keep the data in the form and display the errors. Do not save any recs until there are no errors in the form
       if ($errors !== []) {
-        $errorMessage = $this->formatErrors($errors);
-        return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
+          $errorMessage = $this->formatErrors($errors);
+          return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
       } else {
           // Once there are no errors, go through the filled in rec forms and create the recs
-          foreach ($recs as $key=>$rec) {
-            if (array_filter($rec)) {
+          foreach ($recs as $key => $rec) {
+              if (array_filter($rec)) {
 
-              $recommendation = new Recommendation();
-              $recommendation->fill($rec);
+                $recommendation = new Recommendation();
+                $recommendation->fill($rec);
 
-              $application = Auth::user()->application;
-              $recommendation->application()->associate($application);
-              $recommendation->save();
+                $application = Auth::user()->application;
+                $recommendation->application()->associate($application);
+                $recommendation->save();
 
-              $token = $recommendation->generateRecToken($recommendation);
-              $this->prepareRecRequestConfirmationEmail($recommendation);
-              $this->prepareRecRequestEmail($recommendation, $token);
+                $token = $recommendation->generateRecToken($recommendation);
+                $this->prepareRecRequestConfirmationEmail($recommendation);
+                $this->prepareRecRequestEmail($recommendation, $token);
             }
           }
       }
@@ -117,7 +117,7 @@ class RecommendationController extends \Controller
   }
 
   /**
-   * Formats validation errors from the rec request form and returns a formatted string
+   * Formats validation errors from the rec request form and returns a formatted string.
    *
    * @param  array  $errors
    *
@@ -125,18 +125,18 @@ class RecommendationController extends \Controller
    */
   public function formatErrors($errors)
   {
-    $formatted = '';
+      $formatted = '';
 
-    foreach ($errors as $recNumber=>$errorArray) {
-      $formatted .= 'Recommendation # ' . ($recNumber + 1) . ': <br>';
-      $formatted .= '<ul>';
-      foreach ($errorArray as $error) {
-        $formatted .= '<li>' . $error . '</li>';
+      foreach ($errors as $recNumber=>$errorArray) {
+          $formatted .= 'Recommendation # ' . ($recNumber + 1) . ': <br>';
+          $formatted .= '<ul>';
+          foreach ($errorArray as $error) {
+              $formatted .= '<li>' . $error . '</li>';
+          }
+          $formatted .= '</ul>';
       }
-      $formatted .= '</ul>';
-    }
 
-    return $formatted;
+      return $formatted;
   }
 
   /**
@@ -260,7 +260,7 @@ class RecommendationController extends \Controller
         $recs = $input['rec'];
         $rules = array_merge($this->rules, $this->applicant_rules);
         $errors = [];
-        foreach ($recs as $key=>$rec) {
+        foreach ($recs as $key => $rec) {
             // If rec already exists, update existing rec
           if (isset($rec['id'])) {
               // Do not validate completed recs
@@ -268,17 +268,17 @@ class RecommendationController extends \Controller
                 $v = Validator::make($rec, $rules);
                 // Collect validation errors
                 if ($v->fails()) {
-                  $errors[$key] = $v->errors()->all();
+                    $errors[$key] = $v->errors()->all();
                 }
             }
             // Display errors to user if there are any
             if ($errors !== []) {
-              $errorMessage = $this->formatErrors($errors);
-              return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
+                $errorMessage = $this->formatErrors($errors);
+                return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
             } else {
-              // Update the rec if there are no errors
+                // Update the rec if there are no errors
               $currentRec = Recommendation::whereId($rec['id'])->firstOrFail();
-              $currentRec->fill($rec);
+                $currentRec->fill($rec);
               // Only resend and email to the recommender if the email address was changed
               if ($currentRec->isDirty('email')) {
                   $token = RecommendationToken::where('recommendation_id', $rec['id'])->pluck('token');
@@ -293,22 +293,22 @@ class RecommendationController extends \Controller
                   $v = Validator::make($rec, $rules);
                   // Collect validation errors
                   if ($v->fails()) {
-                    $errors[$key] = $v->errors()->all();
+                      $errors[$key] = $v->errors()->all();
                   }
                   // Display errors to the user
                   if ($errors !== []) {
-                    $errorMessage = $this->formatErrors($errors);
-                    return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
+                      $errorMessage = $this->formatErrors($errors);
+                      return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
                   } else {
-                    // If no errors, save the new rec
-                    $newRec = new Recommendation();
-                    $application = Auth::user()->application;
-                    $newRec->application()->associate($application);
-                    $newRec->fill($rec);
-                    $newRec->save();
-                    $token = $newRec->generateRecToken($newRec);
-                    $this->prepareRecRequestConfirmationEmail($newRec);
-                    $this->prepareRecRequestEmail($newRec, $token);
+                      // If no errors, save the new rec
+                      $newRec = new Recommendation();
+                      $application = Auth::user()->application;
+                      $newRec->application()->associate($application);
+                      $newRec->fill($rec);
+                      $newRec->save();
+                      $token = $newRec->generateRecToken($newRec);
+                      $this->prepareRecRequestConfirmationEmail($newRec);
+                      $this->prepareRecRequestEmail($newRec, $token);
                 }
             }
         }

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -93,22 +93,22 @@ class RecommendationController extends \Controller
       // If there are any errors in the form, keep the data in the form and display the errors. Do not save any recs until there are no errors in the form
       if ($errors !== []) {
           $errorMessage = $this->formatErrors($errors);
+
           return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
       } else {
           // Once there are no errors, go through the filled in rec forms and create the recs
           foreach ($recs as $key => $rec) {
               if (array_filter($rec)) {
+                  $recommendation = new Recommendation();
+                  $recommendation->fill($rec);
 
-                $recommendation = new Recommendation();
-                $recommendation->fill($rec);
+                  $application = Auth::user()->application;
+                  $recommendation->application()->associate($application);
+                  $recommendation->save();
 
-                $application = Auth::user()->application;
-                $recommendation->application()->associate($application);
-                $recommendation->save();
-
-                $token = $recommendation->generateRecToken($recommendation);
-                $this->prepareRecRequestConfirmationEmail($recommendation);
-                $this->prepareRecRequestEmail($recommendation, $token);
+                  $token = $recommendation->generateRecToken($recommendation);
+                  $this->prepareRecRequestConfirmationEmail($recommendation);
+                  $this->prepareRecRequestEmail($recommendation, $token);
             }
           }
       }
@@ -127,11 +127,11 @@ class RecommendationController extends \Controller
   {
       $formatted = '';
 
-      foreach ($errors as $recNumber=>$errorArray) {
-          $formatted .= 'Recommendation # ' . ($recNumber + 1) . ': <br>';
+      foreach ($errors as $recNumber => $errorArray) {
+          $formatted .= 'Recommendation # '.($recNumber + 1).': <br>';
           $formatted .= '<ul>';
           foreach ($errorArray as $error) {
-              $formatted .= '<li>' . $error . '</li>';
+              $formatted .= '<li>'.$error.'</li>';
           }
           $formatted .= '</ul>';
       }
@@ -274,6 +274,7 @@ class RecommendationController extends \Controller
             // Display errors to user if there are any
             if ($errors !== []) {
                 $errorMessage = $this->formatErrors($errors);
+
                 return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
             } else {
                 // Update the rec if there are no errors
@@ -285,7 +286,7 @@ class RecommendationController extends \Controller
                   $this->prepareRecRequestEmail($currentRec, $token);
                   $this->prepareRecRequestConfirmationEmail($currentRec);
               }
-              $currentRec->save();
+                $currentRec->save();
             }
           } else {
               // True if any fields are filled in
@@ -298,6 +299,7 @@ class RecommendationController extends \Controller
                   // Display errors to the user
                   if ($errors !== []) {
                       $errorMessage = $this->formatErrors($errors);
+
                       return redirect()->back()->withInput()->with('flash_message', ['text' => 'There is an error in your submission.<br>'. $errorMessage, 'class' => '-error']);
                   } else {
                       // If no errors, save the new rec
@@ -309,9 +311,9 @@ class RecommendationController extends \Controller
                       $token = $newRec->generateRecToken($newRec);
                       $this->prepareRecRequestConfirmationEmail($newRec);
                       $this->prepareRecRequestEmail($newRec, $token);
-                }
-            }
-        }
+                  }
+              }
+          }
         }
 
         return redirect()->route('status')->with('flash_message', ['text' => 'Everything updated!', 'class' => '-success']);

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -42,7 +42,7 @@
 
         @if (Session::has('flash_message'))
           <div class="flash-message {{ Session::get('flash_message')['class'] }}">
-            <em>{{ Session::get('flash_message')['text'] }}</em>
+            <em>{!! Session::get('flash_message')['text'] !!}</em>
           </div>
         @endif
 


### PR DESCRIPTION
#### What's this PR do?
A whole lot of good (in my opinion) things!
- when first requesting a recommendation, ALL of them will save and not just the first one
- the form does not save until there are no validation errors (I think that's okay)
- validation errors are displayed like this now (which is a huuuuge improvement):

![image](https://cloud.githubusercontent.com/assets/4240292/19121533/e1b6fda2-8af4-11e6-8f7a-eb2277fc4eeb.png)

- once the form is saved, the user is redirected to the status page (this is the same)

#### How should this be reviewed?
See if I've included enough good comments and if this approach makes sense in general

#### Checklist
- [ ] Tested on Whitelabel.

