### PR TITLE
make form submit buttons readonly after click

### DIFF
--- a/resources/assets/js/form-loader.js
+++ b/resources/assets/js/form-loader.js
@@ -1,0 +1,17 @@
+var $ = require('jquery');
+
+/**
+ * Add a 'loading' indicator and prevent double
+ * form submission from over-eager clickers.
+ */
+function initialize() {
+  $(document.body).on('submit', 'form', function() {
+    const submits = this.querySelectorAll('input[type="submit"], button[type="submit"]');
+
+    Array.prototype.forEach.call(submits, function(button) {
+      button.setAttribute('readonly', 'readonly');
+    });
+  });
+}
+
+export default { initialize };

--- a/resources/assets/js/main.js
+++ b/resources/assets/js/main.js
@@ -1,3 +1,5 @@
+import formLoader from './form-loader';
+
 var $      = require('jquery');
 var Panels = require('./panels');
 var Modal  = require('./modal');
@@ -10,6 +12,9 @@ var $mainNav   = $('#main-nav');
 
 
 Panels.init($container, $mainNav);
+
+// Prevent form double submission
+formLoader.initialize();
 
 
 // If there's a designated content modal, then lets activate it!


### PR DESCRIPTION
#### What's this PR do?
JS city!
Adds JS to change form submit buttons to `readonly` once they are clicked once. This will allow their values to still be passed while being essentially `disabled` aka we get all the info we need, but users can't click them again.

#### How should this be reviewed?
Check that I included everything necessary for JS land.

#### Any background context you want to provide?
We think forms being submitted on top of themselves is the root of the CSRF Token Mismatch errors we are seeing so hopefully this will fix that.

#### Checklist
- [ ] Tested on Whitelabel.
