### PR TITLE
handle users hitting routes that we don't really use

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -47,12 +47,13 @@ class ApplicationController extends \Controller
     }
 
   /**
-   * This isn't a real route, so redirect to the homepage if someone hits it in error
+   * This isn't a real route, so redirect to the homepage if someone hits it in error.
    *
    * @return Response
    */
-  public function index() {
-    return redirect()->route('home');
+  public function index()
+  {
+      return redirect()->route('home');
   }
 
   /**
@@ -116,7 +117,7 @@ class ApplicationController extends \Controller
   }
 
   /**
-   * We very rarely use show, but sometimes people hit it somehow so we should handle it
+   * We very rarely use show, but sometimes people hit it somehow so we should handle it.
    *
    * @param  int  $id
    *
@@ -126,9 +127,9 @@ class ApplicationController extends \Controller
   {
       // If there is an application, direct to edit, otherwise to create (edit handles making sure it is the correct user)
       if (Application::where('user_id', $id)->first()) {
-        return redirect()->route('application.edit', $id);
-      }  else {
-        return redirect()->route('application.create');
+          return redirect()->route('application.edit', $id);
+      } else {
+          return redirect()->route('application.create');
       }
   }
 
@@ -143,7 +144,7 @@ class ApplicationController extends \Controller
   {
       // Make sure the user is only seeing their own application
       if (Auth::user()->id != $id) {
-        // Direct the user to show to edit or create their own application
+          // Direct the user to show to edit or create their own application
         return redirect()->route('application.show', Auth::user()->id);
       }
       // @TODO: add a filter here to check for app complete.

--- a/app/Http/Controllers/NominationController.php
+++ b/app/Http/Controllers/NominationController.php
@@ -31,12 +31,13 @@ class NominationController extends \Controller
     }
 
   /**
-   * This isn't a real route, so redirect to the homepage if someone hits it in error
+   * This isn't a real route, so redirect to the homepage if someone hits it in error.
    *
    * @return Response
    */
-  public function index() {
-    return redirect()->route('home');
+  public function index()
+  {
+      return redirect()->route('home');
   }
 
     public function store(Request $request)

--- a/app/Http/Controllers/NominationController.php
+++ b/app/Http/Controllers/NominationController.php
@@ -30,6 +30,15 @@ class NominationController extends \Controller
     {
     }
 
+  /**
+   * This isn't a real route, so redirect to the homepage if someone hits it in error
+   *
+   * @return Response
+   */
+  public function index() {
+    return redirect()->route('home');
+  }
+
     public function store(Request $request)
     {
         // $input = Input::all();

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -47,7 +47,7 @@ class ProfilesController extends \Controller
    */
   public function index()
   {
-    return redirect()->route('home');
+      return redirect()->route('home');
   }
 
   /**

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -4,7 +4,6 @@ use App\Models\Application;
 use App\Models\Profile;
 use App\Models\Race;
 use App\Models\User;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Scholarship\Repositories\SettingRepository;
 
@@ -117,9 +116,9 @@ class ProfilesController extends \Controller
   {
       // If there is a profile, direct to edit, otherwise to create (edit handles making sure it is the correct user)
       if (Profile::where('user_id', $id)->first()) {
-        return redirect()->route('profile.edit', $id);
-      }  else {
-        return redirect()->route('profile.create');
+          return redirect()->route('profile.edit', $id);
+      } else {
+          return redirect()->route('profile.create');
       }
   }
 
@@ -134,7 +133,7 @@ class ProfilesController extends \Controller
   {
       // Make sure the user is only seeing their own profile
       if (Auth::user()->id != $id) {
-        // Direct the user to show to edit or create their own application
+          // Direct the user to show to edit or create their own application
         return redirect()->route('profile.show', Auth::user()->id);
       }
 

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -41,11 +41,12 @@ class ProfilesController extends \Controller
     }
 
   /**
-   * This isn't a real route, so redirect to the homepage if someone hits it in error
+   * This isn't a real route, so redirect to the homepage if someone hits it in error.
    *
    * @return Response
    */
-  public function index() {
+  public function index()
+  {
     return redirect()->route('home');
   }
 

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -48,6 +48,15 @@ class RecommendationController extends \Controller
     }
 
   /**
+   * This isn't a real route, so redirect to the homepage if someone hits it in error
+   *
+   * @return Response
+   */
+  public function index() {
+    return redirect()->route('home');
+  }
+
+  /**
    * Show the form for creating a new resource.
    * GET /recommendation/create.
    *
@@ -151,7 +160,8 @@ class RecommendationController extends \Controller
    */
   public function show($id)
   {
-      //
+      // @TODO: this is getting hit on occasion, but since we have query parameters in edit I don't think we can really direct them anywhere except the homepage
+      return redirect()->route('home');
   }
 
   /**

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -48,12 +48,13 @@ class RecommendationController extends \Controller
     }
 
   /**
-   * This isn't a real route, so redirect to the homepage if someone hits it in error
+   * This isn't a real route, so redirect to the homepage if someone hits it in error.
    *
    * @return Response
    */
-  public function index() {
-    return redirect()->route('home');
+  public function index()
+  {
+      return redirect()->route('home');
   }
 
   /**

--- a/app/Http/Controllers/RegistrationController.php
+++ b/app/Http/Controllers/RegistrationController.php
@@ -42,11 +42,12 @@ class RegistrationController extends \Controller
     }
 
   /**
-   * This isn't a real route, so redirect to the homepage if someone hits it in error
+   * This isn't a real route, so redirect to the homepage if someone hits it in error.
    *
    * @return Response
    */
-  public function index() {
+  public function index()
+  {
     return redirect()->route('home');
   }
 

--- a/app/Http/Controllers/RegistrationController.php
+++ b/app/Http/Controllers/RegistrationController.php
@@ -48,7 +48,7 @@ class RegistrationController extends \Controller
    */
   public function index()
   {
-    return redirect()->route('home');
+      return redirect()->route('home');
   }
 
   /**

--- a/app/Http/Controllers/RegistrationController.php
+++ b/app/Http/Controllers/RegistrationController.php
@@ -42,6 +42,15 @@ class RegistrationController extends \Controller
     }
 
   /**
+   * This isn't a real route, so redirect to the homepage if someone hits it in error
+   *
+   * @return Response
+   */
+  public function index() {
+    return redirect()->route('home');
+  }
+
+  /**
    * Show the form for creating a new resource.
    * /register.
    *

--- a/app/Http/Middleware/CheckIfCurrentUser.php
+++ b/app/Http/Middleware/CheckIfCurrentUser.php
@@ -30,12 +30,8 @@ class CheckIfCurrentUser
     public function handle($request, Closure $next)
     {
         if (Auth::guest()) {
-            return redirect()->home();
+            return redirect()->route('login')->with('flash_message', ['text' => 'You must be logged in to do that.', 'class' => '-warning']);
         }
-          // // @TODO: protect both the applicaiton/profile edit routes!
-          // if (Auth::user()->id !== (int)$route->parameter('profile')) {
-          //   return Redirect::home();
-          // }
 
         return $next($request);
     }

--- a/app/Http/Middleware/CheckIfCurrentUser.php
+++ b/app/Http/Middleware/CheckIfCurrentUser.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Middleware;
 
-use App\Models\User;
 use Auth;
 use Closure;
 use Scholarship\Repositories\SettingRepository;


### PR DESCRIPTION
#### What's this PR do?
- Adds index functions on almost everything that redirect to the homepage. We are getting errors from users hitting these routes that don't really exist. Hopefully with the submit button going `readonly` after 1 click people won't be hitting them anymore, but just in case let's not get errors.
- Fixes some middleware/access logic (like if they need to be logged in let's redirect them to the login page instead of the homepage)
- On some models (application, profile, recommendation), the `show` route was being hit. For application and profile, we redirect the user to the edit page if there is a model for that id (and then the edit function takes care of making sure that the id in the url and that user's id are the same). If not, we direct them to the edit page. For recommendation, we need extra info from the request so we can't really direct them to edit or anything, so we send them to the homepage.

#### How should this be reviewed?
This shouldn't affect the regular flow because unless you go to one of these routes on purpose or hit an error and end up here by mistake, you will never land on these routes. So make sure the flow is the same!

#### Any background context you want to provide?
We think these routes are being hit because of form double submission and then laravel somehow ending up falling back on these routes? Unclear.

#### Checklist
- [ ] Tested on Whitelabel.

cc: @ngjo I'm going to ping you to check out the flow once this is on whitelabel
