### PR TITLE
add mc:disable-tracking to not add extra mandrill parameters on rec requests

### DIFF
--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -349,7 +349,8 @@ class RecommendationController extends \Controller
    */
   public function prepareRecRequestEmail($recommendation, $token)
   {
-      $link = link_to_route('recommendation.edit', 'Please provide a recommendation', [$recommendation->id, 'token' => $token]);
+      $link = '<a href="'.url('/').'/recommendation/'.$recommendation->id.'/edit?token='.$token.'" mc:disable-tracking>Please provide a recommendation</a>';
+
       $email = new Email();
       $data = [
       'link'           => $link,

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -153,7 +153,8 @@ class StatusController extends \Controller
         $recommendation = Recommendation::whereId($rec_id)->firstOrFail();
         $token = $recommendation->generateRecToken($recommendation);
 
-        $link = link_to_route('recommendation.edit', 'Please provide a recommendation', [$recommendation->id, 'token' => $token]);
+        $link = '<a href="'.url('/').'/recommendation/'.$recommendation->id.'/edit?token='.$token.'" mc:disable-tracking>Please provide a recommendation</a>';
+
         $email = new Email();
         $data = [
           'link'           => $link,

--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -386,7 +386,7 @@ class AdminController extends \Controller
       $rec_id = Input::get('rec_id');
         $recommendation = Recommendation::whereId($rec_id)->firstOrFail();
         $token = RecommendationToken::where('recommendation_id', $recommendation->id)->first()->token;
-        $link = link_to_route('recommendation.edit', 'Please provide a recommendation', [$recommendation->id, 'token' => $token]);
+        $link = '<a href="'.url('/').'/recommendation/'.$recommendation->id.'/edit?token='.$token.'" mc:disable-tracking>Please provide a recommendation</a>';
 
       // get applicant info
       $applicant_id = Input::get('applicant_id');


### PR DESCRIPTION
#### What's this PR do?
Some recommender links are getting their query parameters chopped off after they leave mandrill. This might be because of the extra mandrill tracking parameters that are added to track the clicks. Since this extra link length ⛓ might be what is causing the links to be truncated 🐘, we want to remove the parameters on these links 🌭. [Mandrill details](https://mandrill.zendesk.com/hc/en-us/articles/205582927-Can-I-disable-click-tracking-on-selected-links-in-my-email-) how to disable this for certain links. However, 'link_to_route' doesn't seem to accept attribute parameters that aren't in the form of `blah-stuff=whateva` so the links had to be constructed piecemeal. 

#### How should this be reviewed?
I've tested this with all 3 ways that a rec request can be sent, but we want to make sure that the newly constructed link still works, but we want to make sure the link itself doesn't actually change.

#### Any background context you want to provide?
As detailed by @mshmsh5000 in slack (from [here](https://mandrill.zendesk.com/hc/en-us/articles/205582897-Why-aren-t-clicks-being-tracked-)):
> Some internet browsers and email clients break links that are over a certain length.

#### Checklist
- [ ] Tested on Whitelabel.

