### PR TITLE
handle token mismatches

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Session\TokenMismatchException;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -48,6 +49,11 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        if ($e instanceof TokenMismatchException) {
+            // If a user gets a token mismatch when submitting a form, bring them back to the form with all their input, but tell them to try again
+            return redirect()->back()->withInput()->with('flash_message', ['text' => 'There was an error processing your submission, please try again.', 'class' => '-error']);
+        }
+
         return parent::render($request, $e);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
If a user gets a `TokenMismatchException`, redirect them back to the page they were on with a red message that says `There was an error processing your submission, please try again.` This way an applicant will not lose all of the data they had entered. If their session really has ended, that data would be lost anyway and they should end up with a message asking them to login.

#### How should this be reviewed?
Test 1:
I manually threw some token mismatch exceptions on controller functions that get hit when saving forms to mimic what has been happening to some users. I was properly redirected back to the form with all my entries still there and with the flash message.

Test 2:
Additionally, I manually logged out the user after the mismatch was caught to make sure they are properly redirected to a page that asks them to login should their session actually have ended.

Let me know if there are other ways that I should have tested this.

#### Any background context you want to provide?
This is a solution that helped [some other people on the internet](https://laracasts.com/discuss/channels/laravel/random-tokenmismatchexceptions).


#### Checklist
- [ ] Tested on Whitelabel.

cc: @DFurnes 