### PR TITLE
allow html in editable application questions

### DIFF
--- a/resources/views/admin/applications/show.blade.php
+++ b/resources/views/admin/applications/show.blade.php
@@ -66,7 +66,7 @@
                   @if (!empty($field))
                     {{-- Does the field have a better title in the scholarship? --}}
                     @if (isset($scholarship[$key]))
-                      <p><strong>{{ snakeCaseToTitleCase($scholarship[$key]) }}</strong></p>
+                      <p><strong>{!! snakeCaseToTitleCase($scholarship[$key]) !!}</strong></p>
                     @else
                       <p><strong>{{ snakeCaseToTitleCase($key) }}</strong></p>
                     @endif

--- a/resources/views/application/partials/_form_application.blade.php
+++ b/resources/views/application/partials/_form_application.blade.php
@@ -1,6 +1,6 @@
   {{-- Accomplishments --}}
   <div class="field-group {{ setInvalidClass('accomplishments', $errors) }}">
-    {!! Form::label('accomplishments', $label['accomplishments']) !!}
+    {!! $label['accomplishments'] !!}
     {!! Form::textarea('accomplishments') !!}
     {!! errorsFor('accomplishments', $errors); !!}
   </div>
@@ -30,21 +30,21 @@
 
   {{-- Activities --}}
   <div class="field-group {{ setInvalidClass('activities', $errors) }}">
-    {!! Form::label('activities', $label['activities']) !!}
+    {!! $label['activities'] !!}
     {!! Form::textarea('activities') !!}
     {!! errorsFor('activities', $errors); !!}
   </div>
 
     {{-- Participation --}}
   <div class="field-group {{ setInvalidClass('activities', $errors) }}">
-    {!! Form::label('participation', $label['participation']) !!}
+    {!! $label['participation'] !!}
     {!! Form::textarea('participation') !!}
     {!! errorsFor('participation', $errors); !!}
   </div>
 
   {{-- Essay 1 --}}
   <div class="field-group {{ setInvalidClass('essay1', $errors) }}">
-    {!! Form::label('essay1', $label['essay1']) !!}
+    {!! $label['essay1'] !!}
     {!! Form::textarea('essay1') !!}
     {!! errorsFor('essay1', $errors); !!}
   </div>
@@ -52,7 +52,7 @@
 
   {{-- Essay 2 --}}
   <div class="field-group {{ setInvalidClass('essay2', $errors) }}">
-    {!! Form::label('essay2', $label['essay2']) !!}
+    {!! $label['essay2'] !!}
     {!! Form::textarea('essay2') !!}
     {!! errorsFor('essay2', $errors); !!}
   </div>


### PR DESCRIPTION
#### What's this PR do?
Allow admins to use HTML in editable questions so they can put cool links like this:
![image](https://cloud.githubusercontent.com/assets/4240292/20110286/d3b7a8f0-a5b1-11e6-9e1f-5c1dd4ae7e1e.png)

#### How should this be reviewed?
Does HTML in these fields show up right?

#### Any background context you want to provide?
I noticed on CAPS there was some markdown in these fields that wasn't showing up right.

#### Relevant tickets
Fixes #868 

#### Checklist
- [ ] Tested on Whitelabel.

