### PR TITLE
Fixes bug where emails to people involved with nominations did not work

### DIFF
--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -348,7 +348,7 @@ class AdminController extends \Controller
         $tokens = [];
         foreach ($query_result as $row) {
             // Some emails are stored under a different column, and we get them "as Email"
-            $send_to = isset($row->email) ? $row->email : $row->Email;
+            $send_to = $row->email;
 
             // Define row specific tokens
             if (isset($row->first_name)) {

--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -347,7 +347,8 @@ class AdminController extends \Controller
         // For each result, construct and send the email
         $tokens = [];
         foreach ($query_result as $row) {
-            $send_to = $row->email;
+            // Some emails are stored under a different column, and we get them "as Email"
+            $send_to = isset($row->email) ? $row->email : $row->Email;
 
             // Define row specific tokens
             if (isset($row->first_name)) {

--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -347,7 +347,7 @@ class AdminController extends \Controller
         // For each result, construct and send the email
         $tokens = [];
         foreach ($query_result as $row) {
-            // Some emails are stored under a different column, and we get them "as Email"
+            // Grab the email address
             $send_to = $row->email;
 
             // Define row specific tokens

--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -45,7 +45,7 @@ class Export extends Model
 
     public static function nominated_no_app_query()
     {
-        $results = DB::select('SELECT n.nom_name, n.nom_email
+        $results = DB::select('SELECT n.nom_name as Nominee, n.nom_email as Email
                            FROM nominations n
                            WHERE not exists (SELECT *
                                              FROM users u

--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -45,7 +45,7 @@ class Export extends Model
 
     public static function nominated_no_app_query()
     {
-        $results = DB::select('SELECT n.nom_name as Nominee, n.nom_email as email
+        $results = DB::select('SELECT n.nom_name, n.nom_email as email
                            FROM nominations n
                            WHERE not exists (SELECT *
                                              FROM users u

--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -45,7 +45,7 @@ class Export extends Model
 
     public static function nominated_no_app_query()
     {
-        $results = DB::select('SELECT n.nom_name as Nominee, n.nom_email as Email
+        $results = DB::select('SELECT n.nom_name as Nominee, n.nom_email as email
                            FROM nominations n
                            WHERE not exists (SELECT *
                                              FROM users u
@@ -79,7 +79,7 @@ class Export extends Model
 
     public static function nominators_query()
     {
-        $results = DB::select('SELECT DISTINCT rec_name as Name, rec_email as Email
+        $results = DB::select('SELECT DISTINCT rec_name as Name, rec_email as email
                           FROM nominations');
 
         return $results;
@@ -87,7 +87,7 @@ class Export extends Model
 
     public static function nominees_query()
     {
-        $results = DB::select('SELECT DISTINCT nom_name as Name, nom_email as Email
+        $results = DB::select('SELECT DISTINCT nom_name as Name, nom_email as email
                           FROM nominations');
 
         return $results;


### PR DESCRIPTION
#### What's this PR do?
When sending emails to groups, we were trying to grab the `email` from each row of the query made to construct the group. However, when dealing with nominations nothing is stored as `email` since there are two emails: the nominator email and the nominee email.

The queries to get the nominators and the nominees are [here](https://github.com/DoSomething/longshot/blob/master/app/models/Export.php#L80-L94).

Since in the query, the emails are grabbed `as Email`, I added a check to grab `Email` if `email` is not set. I also updated the `nominated_no_app_query` to grab the nominee email address as `Email` so I didn't have to make a third check for `nom_email`.

#### How should this be reviewed?
Would we be able to successfully grab the email from each query in [Export.php](https://github.com/DoSomething/longshot/blob/master/app/models/Export.php)?

Note: I think the group email will not work for the `yes_applicants_query`, but I do not think that is used. I will find out more about that.

#### Any background context you want to provide?
It's all above!

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/150071752)

#### Checklist
- [ ] Tested on Whitelabel.
