### PR TITLE
Add new SAT test type options

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -12,7 +12,7 @@ class ApplicationController extends \Controller
     'accomplishments' => 'required',
     'participation'   => 'required',
     'gpa'             => 'required|numeric',
-    'test_score'      => 'numeric|required_if:test_type,PSAT,SAT,PLAN,ACT',
+    'test_score'      => 'numeric|required_if:test_type,PSAT,SAT (Out of 2400),SAT (Out of 1600),PLAN,ACT',
     'activities'      => 'required',
     'essay1'          => 'required',
     'essay2'          => 'required',

--- a/resources/views/application/partials/_form_application.blade.php
+++ b/resources/views/application/partials/_form_application.blade.php
@@ -16,7 +16,7 @@
   {{-- Test Type --}}
   <div class="field-group -mono {{ setInvalidClass('test_type', $errors) }}">
     {!! Form::label('test_type', 'Test Type:') !!}
-    {!! Form::select('test_type', array('PSAT' => 'PSAT', 'SAT' => 'SAT', 'PLAN' => 'PLAN', 'ACT' => 'ACT', 'Prefer not to submit scores' => 'Prefer not to submit scores')); !!}
+    {!! Form::select('test_type', array('PSAT' => 'PSAT', 'SAT (Out of 1600)' => 'SAT (Out of 1600)', 'SAT (Out of 2400)' => 'SAT (Out of 2400)', 'PLAN' => 'PLAN', 'ACT' => 'ACT', 'Prefer not to submit scores' => 'Prefer not to submit scores')); !!}
     {!! errorsFor('test_type', $errors); !!}
   </div>
 


### PR DESCRIPTION
#### What's this PR do?
Adds two new test type options to the test dropdown on the application, `SAT (Out of 1600)` and `SAT (Out of 2400)`. This way, admins can tell which test the student took if they have an ambiguous score like `1500`. This also updated the validation to force applicants to input a numerical score if they have selected either one of these options.

#### How should this be reviewed?
Can you successfully choose either of these options? Do you get a validation error if you select one of these options but don't input a score?

#### Relevant tickets
Pivotal [card](https://www.pivotaltracker.com/story/show/150027511)

#### Checklist
- [ ] Tested on Whitelabel.
