### PR TITLE
Allow admins to toggle ability for applicants to upload photos

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -67,10 +67,11 @@ class ApplicationController extends \Controller
       $current_scholarship_id = Scholarship::getCurrentScholarship()->id;
       $label = Scholarship::getScholarshipLabels($current_scholarship_id);
       $hear_about = Scholarship::getCurrentScholarship()->hear_about_options;
+      $image_uploads = Scholarship::getCurrentScholarship()->image_uploads;
       $choices = Application::formatChoices($hear_about);
       $vars = (object) $this->settings->getSpecifiedSettingsVars(['application_create_help_text']);
 
-      return view('application.create')->with(compact('label', 'choices', 'vars'));
+      return view('application.create')->with(compact('label', 'choices', 'vars', 'image_uploads'));
   }
 
   /**

--- a/app/Http/Controllers/admin/ScholarshipController.php
+++ b/app/Http/Controllers/admin/ScholarshipController.php
@@ -77,13 +77,19 @@ class ScholarshipController extends \Controller
   public function update($id)
   {
       $input = Input::all();
-    // Must explicity get checkbox content to save as boolean, since a non-checked  box doesn't return anything from a form submit.
-    $optional = Input::get('display_optional_rec_question');
+
+      // Must explicity get checkbox content to save as boolean, since a non-checked  box doesn't return anything from a form submit.
+      $optional = Input::get('display_optional_rec_question');
+      $images = Input::get('image_uploads');
+
       $scholarship = Scholarship::whereId($id)->firstOrFail();
+
       $scholarship->display_optional_rec_question = $optional;
+      $scholarship->image_uploads = $images;
+
       $scholarship->fill($input)->save();
 
-    // Maybe this should go to scholarship/show?
-    return redirect()->back()->with('flash_message', ['text' => 'Success: Scholarship information has been saved!', 'class' => 'alert-success']);
+      // Maybe this should go to scholarship/show?
+      return redirect()->back()->with('flash_message', ['text' => 'Success: Scholarship information has been saved!', 'class' => 'alert-success']);
   }
 }

--- a/app/Http/Controllers/admin/ScholarshipController.php
+++ b/app/Http/Controllers/admin/ScholarshipController.php
@@ -78,14 +78,11 @@ class ScholarshipController extends \Controller
   {
       $input = Input::all();
 
-      // Must explicity get checkbox content to save as boolean, since a non-checked  box doesn't return anything from a form submit.
-      $optional = Input::get('display_optional_rec_question');
-      $images = Input::get('image_uploads');
-
       $scholarship = Scholarship::whereId($id)->firstOrFail();
 
-      $scholarship->display_optional_rec_question = $optional;
-      $scholarship->image_uploads = $images;
+      // Must explicity get checkbox content to save as boolean, since a non-checked  box doesn't return anything from a form submit.
+      $scholarship->display_optional_rec_question = Input::get('display_optional_rec_question');
+      $scholarship->image_uploads = Input::get('image_uploads');
 
       $scholarship->fill($input)->save();
 

--- a/database/migrations/2017_08_31_144335_add_image_uploads_column_to_scholarships_table.php
+++ b/database/migrations/2017_08_31_144335_add_image_uploads_column_to_scholarships_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddImageUploadsColumnToScholarshipsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('scholarships', function ($table) {
+            $table->boolean('image_uploads')->after('label_app_essay2')->nullable()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('scholarships', function ($table) {
+            $table->dropColumn('image_uploads');
+        });
+    }
+}

--- a/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
+++ b/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
@@ -136,8 +136,8 @@
 
 {{-- Image Uploads --}}
 <div class="form-group">
-  {!! Form::label('image_uploads', 'Allow applicants to upload images?') !!}
-  {!! Form::checkbox('image_uploads', 1, $scholarship->image_uploads) !!}
+  {!! Form::label('image_uploads', 'Allow applicants to upload images') !!}
+  {!! Form::checkbox('image_uploads', 1, $scholarship->image_uploads, ['class' => 'form-control']) !!}
   {!! errorsFor('image_uploads', $errors); !!}
 </div>
 
@@ -164,7 +164,7 @@
 
 {{-- Recommendation Optional question --}}
 <div class="form-group">
-  {!! Form::label('display_optional_rec_question', 'Display optional recommendation question?') !!}
+  {!! Form::label('display_optional_rec_question', 'Display optional recommendation question') !!}
   {!! Form::checkbox('display_optional_rec_question', 1, $scholarship->display_optional_rec_question) !!}
   {!! errorsFor('display_optional_rec_question', $errors); !!}
 </div>

--- a/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
+++ b/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
@@ -137,7 +137,7 @@
 {{-- Image Uploads --}}
 <div class="form-group">
   {!! Form::label('image_uploads', 'Allow applicants to upload images') !!}
-  {!! Form::checkbox('image_uploads', 1, $scholarship->image_uploads, ['class' => 'form-control']) !!}
+  {!! Form::checkbox('image_uploads', 1, $scholarship->image_uploads) !!}
   {!! errorsFor('image_uploads', $errors); !!}
 </div>
 

--- a/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
+++ b/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
@@ -136,8 +136,8 @@
 
 {{-- Image Uploads --}}
 <div class="form-group">
-  {!! Form::label('image_uploads', 'Allow applicants to upload images') !!}
   {!! Form::checkbox('image_uploads', 1, $scholarship->image_uploads) !!}
+  {!! Form::label('image_uploads', 'Allow applicants to upload images') !!}
   {!! errorsFor('image_uploads', $errors); !!}
 </div>
 
@@ -164,8 +164,8 @@
 
 {{-- Recommendation Optional question --}}
 <div class="form-group">
-  {!! Form::label('display_optional_rec_question', 'Display optional recommendation question') !!}
   {!! Form::checkbox('display_optional_rec_question', 1, $scholarship->display_optional_rec_question) !!}
+  {!! Form::label('display_optional_rec_question', 'Display optional recommendation question') !!}
   {!! errorsFor('display_optional_rec_question', $errors); !!}
 </div>
 <div class="form-group">

--- a/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
+++ b/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
@@ -134,6 +134,13 @@
   {!! errorsFor('label_app_essay2', $errors); !!}
 </div>
 
+{{-- Image Uploads --}}
+<div class="form-group">
+  {!! Form::label('image_uploads', 'Allow applicants to upload images?') !!}
+  {!! Form::checkbox('image_uploads', 1, $scholarship->image_uploads) !!}
+  {!! errorsFor('image_uploads', $errors); !!}
+</div>
+
 {{-- Recommendation Rank Character Label --}}
 <div class="form-group">
   {!! Form::label('label_rec_rank_character', 'Recommendation Rank Character Label: ') !!}
@@ -157,8 +164,8 @@
 
 {{-- Recommendation Optional question --}}
 <div class="form-group">
-  {!! Form::label('display_optional_rec_question', 'Display optional recommendation question? ') !!}
-  {!! Form::checkbox('display_optional_rec_question', 1, ['class' => 'form-control']) !!}
+  {!! Form::label('display_optional_rec_question', 'Display optional recommendation question?') !!}
+  {!! Form::checkbox('display_optional_rec_question', 1, $scholarship->display_optional_rec_question) !!}
   {!! errorsFor('display_optional_rec_question', $errors); !!}
 </div>
 <div class="form-group">

--- a/resources/views/application/partials/_form_application.blade.php
+++ b/resources/views/application/partials/_form_application.blade.php
@@ -58,27 +58,29 @@
   </div>
 
   {{-- Upload --}}
-  @if (isset($uploads) && !is_null($uploads))
-    <p>Uploaded Images</p>
-    @foreach ($uploads as $upload)
-      <div class="image-holder">
-        <img src="/storage/app/uploads/{{$user->id}}/{{$upload}}" alt="uploaded image">
-        <p>Remove?</p>
-        {!! Form::checkbox('remove[]', $upload) !!}
+  @if ($image_uploads)
+    @if (isset($uploads) && !is_null($uploads))
+      <p>Uploaded Images</p>
+      @foreach ($uploads as $upload)
+        <div class="image-holder">
+          <img src="/storage/app/uploads/{{$user->id}}/{{$upload}}" alt="uploaded image">
+          <p>Remove?</p>
+          {!! Form::checkbox('remove[]', $upload) !!}
+        </div>
+        <br>
+      @endforeach
+      <div class="field-group">
+        {!! Form::label('upload', 'Additional photos (optional)') !!}
+        {!! Form::file('upload') !!}
+        {!! errorsFor('upload', $errors); !!}
       </div>
-      <br>
-    @endforeach
-    <div class="field-group">
-      {!! Form::label('upload', 'Additional photos (optional)') !!}
-      {!! Form::file('upload') !!}
-      {!! errorsFor('upload', $errors); !!}
-    </div>
-  @else
-    <div class="field-group">
-      {!! Form::label('upload', 'Photos (optional)') !!}
-      {!! Form::file('upload') !!}
-      {!! errorsFor('upload', $errors); !!}
-    </div>
+    @else
+      <div class="field-group">
+        {!! Form::label('upload', 'Photos (optional)') !!}
+        {!! Form::file('upload') !!}
+        {!! errorsFor('upload', $errors); !!}
+      </div>
+    @endif
   @endif
 
   {{-- Hear About --}}


### PR DESCRIPTION
#### What's this PR do?

- Display a "Allow applicants to upload images?" checkbox to admins on the edit scholarship page
- Adds a migration to add a new column `image_uploads` to the `scholarships` table. This will store whether or not the checkbox was checked.
- Fixes the way the other checkbox on the edit scholarship page was being displayed as checked or not (this was not working)
- Conditionally display the photo uploader to the user. This does not impact validation because it is already an optional field.

#### How should this be reviewed?
Is the migration valid? Will the checkboxes work as expected?

#### Any background context you want to provide?
Currently only one scholarship uses the image uploader, so we want to make it optional.

#### Relevant tickets
[Pivotal card
](https://www.pivotaltracker.com/story/show/150058487)

#### Checklist
- [ ] Tested on Whitelabel.
