### PR TITLE
Add 3 new exports

### DIFF
--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -223,6 +223,8 @@ class AdminController extends \Controller
             }
         }
 
+        $image_uploads = Scholarship::getCurrentScholarship()->image_uploads;
+
         $hear_about = Scholarship::getCurrentScholarship()->hear_about_options;
         $choices = Application::formatChoices($hear_about);
 
@@ -240,7 +242,7 @@ class AdminController extends \Controller
 
         $possible_ratings = Rating::getPossibleRatings();
 
-        return view('admin.applications.edit')->withUser($profile)->with(compact('id', 'application', 'app_id', 'user', 'user_info', 'profile', 'races', 'label', 'choices', 'recommendations', 'states', 'show_rating', 'possible_ratings', 'app_rating', 'rank_values', 'user_races'));
+        return view('admin.applications.edit')->withUser($profile)->with(compact('id', 'application', 'app_id', 'user', 'user_info', 'profile', 'races', 'label', 'choices', 'recommendations', 'states', 'show_rating', 'possible_ratings', 'app_rating', 'rank_values', 'user_races', 'image_uploads'));
     }
 
     public function settings()

--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -141,4 +141,16 @@ class Export extends Model
 
         return $results;
     }
+
+  public static function demo_data_query()
+  {
+    $results = DB::select('SELECT u.first_name, u.last_name, p.city, p.state, p.zip, p.gender, p.school, a.hear_about, a.test_type, a.test_score, a.gpa, group_concat(r.race) as race
+                          FROM users u
+                          LEFT JOIN applications a on u.id = a.user_id
+                          LEFT JOIN profiles p on u.id = p.user_id
+                          LEFT JOIN races r on p.id = r.profile_id
+                          GROUP BY u.email');
+
+    return $results;
+  }
 }

--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -212,4 +212,62 @@ class Export extends Model
 
     return $results;
   }
+
+  public static full_app_dump_query()
+  {
+    $results = DB::select('SELECT u.first_name, u.last_name, u.email,
+                          p.birthdate, p.phone, p.address_street, p.address_premise, p.city, p.state, p.zip, p.gender, p.school, p.grade,
+                          a.accomplishments, a.activities, a.participation, a.essay1, a.essay2, a.hear_about, a.test_type, a.test_score, a.gpa,
+                          group_concat(r.race) as race, s.rating,
+
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.first_name SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation First Name 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.last_name SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation Last Name 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.relationship SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation Relationship 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.phone SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation Phone 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.email SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation Email 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_character SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation rank_character 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_additional SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation rank_additional 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.essay1 SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation essay 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.optional_question SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation optional question 1",
+
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.first_name SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation First Name 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.last_name SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation Last Name 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.relationship SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation Relationship 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.phone SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation Phone 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.email SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation Email 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_character SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation rank_character 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_additional SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation rank_additional 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.essay1 SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation essay 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.optional_question SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation optional question 2",
+
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.first_name SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation First Name 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.last_name SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation Last Name 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.relationship SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation Relationship 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.phone SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation Phone 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.email SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation Email 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_character SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation rank_character 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_additional SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation rank_additional 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.essay1 SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation essay 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.optional_question SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation optional question 3",
+
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.first_name SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation First Name 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.last_name SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation Last Name 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.relationship SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation Relationship 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.phone SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation Phone 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.email SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation Email 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_character SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation rank_character 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_additional SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation rank_additional 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.essay1 SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation essay 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.optional_question SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation optional question 4"
+
+                          FROM users u
+                          LEFT JOIN profiles p on u.id = p.user_id
+                          LEFT JOIN races r on r.profile_id = p.id
+                          LEFT JOIN applications a on u.id = a.user_id
+                          LEFT JOIN ratings s on a.id = s.application_id
+                          LEFT JOIN recommendations recs on recs.application_id = a.id
+                          GROUP BY u.email');
+
+    return $results;
+  }
 }

--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -153,4 +153,63 @@ class Export extends Model
 
     return $results;
   }
+
+  public static function full_yes_data()
+  {
+    $results = DB::select('SELECT u.first_name, u.last_name, u.email,
+                          p.birthdate, p.phone, p.address_street, p.address_premise, p.city, p.state, p.zip, p.gender, p.school, p.grade,
+                          a.accomplishments, a.activities, a.participation, a.essay1, a.essay2, a.hear_about, a.test_type, a.test_score, a.gpa,
+                          group_concat(r.race) as race,
+
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.first_name SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation First Name 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.last_name SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation Last Name 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.relationship SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation Relationship 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.phone SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation Phone 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.email SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation Email 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_character SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation rank_character 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_additional SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation rank_additional 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.essay1 SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation essay 1",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.optional_question SEPARATOR "----"),"----"), "----", 1), "----", -1) AS "Recommendation optional question 1",
+
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.first_name SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation First Name 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.last_name SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation Last Name 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.relationship SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation Relationship 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.phone SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation Phone 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.email SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation Email 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_character SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation rank_character 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_additional SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation rank_additional 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.essay1 SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation essay 2",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.optional_question SEPARATOR "----"),"----"), "----", 2), "----", -1) AS "Recommendation optional question 2",
+
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.first_name SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation First Name 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.last_name SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation Last Name 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.relationship SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation Relationship 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.phone SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation Phone 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.email SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation Email 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_character SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation rank_character 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_additional SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation rank_additional 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.essay1 SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation essay 3",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.optional_question SEPARATOR "----"),"----"), "----", 3), "----", -1) AS "Recommendation optional question 3",
+
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.first_name SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation First Name 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.last_name SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation Last Name 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.relationship SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation Relationship 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.phone SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation Phone 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.email SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation Email 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_character SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation rank_character 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.rank_additional SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation rank_additional 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.essay1 SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation essay 4",
+                          SUBSTRING_INDEX(SUBSTRING_INDEX(CONCAT(GROUP_CONCAT(recs.optional_question SEPARATOR "----"),"----"), "----", 4), "----", -1) AS "Recommendation optional question 4"
+
+                          FROM users u
+                          INNER JOIN profiles p on p.user_id = u.id
+                          LEFT JOIN races r on r.profile_id = p.id
+                          INNER JOIN applications a on a.user_id = u.id
+                          INNER JOIN ratings s on s.application_id = a.id
+                          LEFT JOIN recommendations recs on recs.application_id = a.id
+                          WHERE s.rating = "yes"
+                          GROUP BY u.email');
+
+    return $results;
+  }
 }

--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -154,7 +154,7 @@ class Export extends Model
     return $results;
   }
 
-  public static function full_yes_data()
+  public static function full_yes_data_query()
   {
     $results = DB::select('SELECT u.first_name, u.last_name, u.email,
                           p.birthdate, p.phone, p.address_street, p.address_premise, p.city, p.state, p.zip, p.gender, p.school, p.grade,

--- a/app/models/Export.php
+++ b/app/models/Export.php
@@ -213,7 +213,7 @@ class Export extends Model
     return $results;
   }
 
-  public static full_app_dump_query()
+  public static function full_app_data_query()
   {
     $results = DB::select('SELECT u.first_name, u.last_name, u.email,
                           p.birthdate, p.phone, p.address_street, p.address_premise, p.city, p.state, p.zip, p.gender, p.school, p.grade,

--- a/resources/views/admin/reports/export.blade.php
+++ b/resources/views/admin/reports/export.blade.php
@@ -6,6 +6,11 @@
 
       @include('admin.layouts.partials.subnav-applications')
 
+
+        <div class="col-xs-6 col-xs-offset-2 main">
+          <p>For more information about the data exports available on this page and how to use the email functionality, please visit the <a href="https://github.com/DoSomething/longshot/wiki/Group-Emails-and-CSV-Exports-(Admin)">Group Emails and CSV Exports</a> page on the Longshot wiki.</p>
+        </div>
+
          <div class="col-xs-3 col-xs-offset-2 main">
 
         {!! Form::open(['route' => 'email.group']) !!}

--- a/resources/views/admin/reports/export.blade.php
+++ b/resources/views/admin/reports/export.blade.php
@@ -31,7 +31,18 @@
         {!! Form::close() !!}
 
        </div>
+
+
       </div>
+       <div class="row">
+          <div class="col-xs-3 col-xs-offset-2 main">
+           {!! Form::open(['route' => 'export.csv']) !!}
+
+           {!! Form::button('<i class="glyphicon glyphicon-download-alt"></i>Demographic Data', array('type' => 'submit', 'name' => 'demo_data', 'class' => 'btn btn-default btn-lg')) !!}
+
+          {!! Form::close() !!}
+          </div>
+       </div>
     </div>
 
 

--- a/resources/views/admin/reports/export.blade.php
+++ b/resources/views/admin/reports/export.blade.php
@@ -38,7 +38,9 @@
           <div class="col-xs-3 col-xs-offset-2 main">
            {!! Form::open(['route' => 'export.csv']) !!}
 
-           {!! Form::button('<i class="glyphicon glyphicon-download-alt"></i>Demographic Data', array('type' => 'submit', 'name' => 'demo_data', 'class' => 'btn btn-default btn-lg')) !!}
+            {!! Form::button('<i class="glyphicon glyphicon-download-alt"></i>Demographic Data', array('type' => 'submit', 'name' => 'demo_data', 'class' => 'btn btn-default btn-lg')) !!}
+
+            {!! Form::button('<i class="glyphicon glyphicon-download-alt"></i>Yes Applicants Full Data', array('type' => 'submit', 'name' => 'full_yes_data', 'class' => 'btn btn-default btn-lg')) !!}
 
           {!! Form::close() !!}
           </div>

--- a/resources/views/admin/reports/export.blade.php
+++ b/resources/views/admin/reports/export.blade.php
@@ -47,6 +47,8 @@
 
             {!! Form::button('<i class="glyphicon glyphicon-download-alt"></i>Yes Applicants Full Data', array('type' => 'submit', 'name' => 'full_yes_data', 'class' => 'btn btn-default btn-lg')) !!}
 
+            {!! Form::button('<i class="glyphicon glyphicon-download-alt"></i>All Applicants Full Data', array('type' => 'submit', 'name' => 'full_app_data', 'class' => 'btn btn-default btn-lg')) !!}
+
           {!! Form::close() !!}
           </div>
        </div>


### PR DESCRIPTION
#### What's this PR do?
1. Fixes a bug where admins couldn't edit applications
2. Adds 3 new queries:
    - one for just demographic data for all users
    - one for ALL data for users rated as "yes" by admins
    - one for ALL data for ALL users
3. Adds 3 new buttons to the export page for these exports
4. Links to the [corresponding wiki page](https://github.com/DoSomething/longshot/wiki/Group-Emails-and-CSV-Exports-(Admin)) from the exports page

Export page now looks like this:
![image](https://user-images.githubusercontent.com/4240292/30081921-f95bcdc4-9256-11e7-99f4-f73da6bbad87.png)

#### How should this be reviewed?
Two of these queries are monsters but they have been working for me. Did I make a silly error in the queries? Does the exports page look okay?

#### Any background context you want to provide?
If the admins can get all the data into excel, they have more flexibility to manipulate it. As usual, let me know if you have ANY questions 😺 

#### Relevant tickets
[Pivotal card
](https://www.pivotaltracker.com/story/show/150027878)
[Pivotal card
](https://www.pivotaltracker.com/story/show/149264549)

#### Checklist
- [ ] Tested on Whitelabel.
