### PR TITLE
Don't check boxes if scholarship not created yet

### DIFF
--- a/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
+++ b/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
@@ -136,7 +136,7 @@
 
 {{-- Image Uploads --}}
 <div class="form-group">
-  {!! Form::checkbox('image_uploads', 1, $scholarship->image_uploads) !!}
+  {!! Form::checkbox('image_uploads', 1, isset($scholarship->image_uploads) ? $scholarship->image_uploads : false) !!}
   {!! Form::label('image_uploads', 'Allow applicants to upload images') !!}
   {!! errorsFor('image_uploads', $errors); !!}
 </div>
@@ -164,7 +164,7 @@
 
 {{-- Recommendation Optional question --}}
 <div class="form-group">
-  {!! Form::checkbox('display_optional_rec_question', 1, $scholarship->display_optional_rec_question) !!}
+  {!! Form::checkbox('display_optional_rec_question', 1, isset($scholarship->display_optional_rec_question) ? $scholarship->display_optional_rec_question : false) !!}
   {!! Form::label('display_optional_rec_question', 'Display optional recommendation question') !!}
   {!! errorsFor('display_optional_rec_question', $errors); !!}
 </div>


### PR DESCRIPTION
#### What's this PR do?
On the form to create or edit a scholarship, we now check if the scholarship exists (aka if the form is to create or edit a scholarship) before trying to use values from the scholarship. In this case, we are seeing if 2 boxes should be checked. If the scholarship doesn't exist yet, don't check the boxes. Otherwise, check them based on how they are set in the scholarship.

#### How should this be reviewed?
Does this do what I said it would?

#### Any background context you want to provide?
I introduced this bug in https://github.com/DoSomething/longshot/pull/881

#### Checklist
- [ ] Tested on Whitelabel.
