### PR TITLE
Never let there be duplicate profiles or applications

### DIFF
--- a/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
+++ b/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
@@ -177,7 +177,7 @@
 
 {{-- How did you hear options? --}}
 <div class="form-group">
-  {!! Form::label('hear_about_options', 'Hear about this options (comma seperated list) ') !!}
+  {!! Form::label('hear_about_options', 'Hear about this options (comma separated list) ') !!}
   {!! Form::text('hear_about_options', null, ['class' => 'form-control']) !!}
   {!! errorsFor('hear_about_options', $errors); !!}
 </div>


### PR DESCRIPTION
#### What's this PR do?
This fixes a bug that I was not able to duplicate until recently. In some cases, there were duplicate applications for users. I found that the profiles can also be duplicated, but that is not as obvious unless you are looking at the database.

Duplication happened when the following took place:
1. A user starts working on their profile or application (from the `/create` page)
2. The user clicks "save as draft" and is sent to the `/edit` page
3. The user goes back in their browser
4. The user makes more updates to the form and submits again
5. BOOM two copies! Maybe more depending on how many times you did that!

The fixes:
1. If a user hits `/create` and they already have an application or profile, redirect them to the edit page.
2. If a user DOES go back to `/create` in their browser (in which case they would not be redirected to `/edit`) they might click either "save as draft" or "save and continue."
    - If they click "save as draft" their changes will be saved to their existing application or profile and they will end up on the `/edit` pages with a message that their information has saved (this is the same behavior as when they click that button when already on the `/edit` page)
    - If they click "save and continue," normally that is when their form would be validated. However, we can't do that here because if there are validation errors, it would redirect them back to the `/create` page which would then redirect them to the `/edit` page and all of the validation information and their updates would be lost. Instead, in this case, this button acts the same as the "save as draft" button and the user ends up on the `/edit` page with their changes saved and a message that they need to click "save and continue" to finish up.

#### How should this be reviewed?
Does this flow make sense? I figure we would rather have the user click one more button than risk having duplicates in different states of completion which could cause completed questions to appear lost if the wrong version is pulled up. This way, the user will not lose any work on their application.

#### Any background context you want to provide?
I have seen a lot of duplicated applications in production. That is really bad because we need to be sure we have (and are presenting applicants with) the most recently submitted version.

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/150902134)

#### Checklist
- [ ] Tested on Whitelabel.
