### PR TITLE
Fix `isClosed()` logic on Scholarships

### DIFF
--- a/app/models/Scholarship.php
+++ b/app/models/Scholarship.php
@@ -42,6 +42,8 @@ class Scholarship extends Model
    */
   public static function isClosed($type = 'application')
   {
+      $start_date = self::getCurrentScholarship()->application_start;
+
       if ($type === 'application') {
           $end_date = self::getCurrentScholarship()->application_end;
       }
@@ -50,7 +52,7 @@ class Scholarship extends Model
           $end_date = self::getCurrentScholarship()->nomination_end;
       }
 
-      return date_has_expired($end_date);
+      return date_has_expired($end_date) || !date_has_expired($start_date);
   }
 
   /**


### PR DESCRIPTION
#### What's this PR do?
There was a flaw in the `isClosed()` logic. We were correctly checking if the current date was AFTER the application end date, but not it if it was before the application start date. Any nominations or accounts must be created after the start date but before the end date.

Scholarships are only open if:
`date_has_expired($end_date) || !date_has_expired($start_date);`
The `$end_date` has not yet happened or the `$start_date` has already happened.

#### How should this be reviewed?
Does this logic make sense for before the start date, between the start date and the end date, and after the end date?

#### Any background context you want to provide?
I think normally this wasn't a problem because we always grabbed the `currentScholarship` but if somehow we end up caching the newest one before the start date, then we need to check on the start date.

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/n/projects/2019429/stories/151400722)

#### Checklist
- [ ] Tested on Whitelabel.
