### PR TITLE
Fix `getPastScholarship()` function

### DIFF
--- a/app/models/Scholarship.php
+++ b/app/models/Scholarship.php
@@ -99,7 +99,7 @@ class Scholarship extends Model
    */
   public static function getPastScholarship($id)
   {
-      $path = Cache::remember('scholarships', 120, function () use ($id) {
+      $path = Cache::remember('scholarships.'.$id, 120, function () use ($id) {
           return self::whereId($id)->first();
       });
 


### PR DESCRIPTION
#### What's this PR do?
`getPastScholarship()` was always returning the current scholarship, no matter which `$id` it was passed. The current scholarship is elsewhere cached as `scholarship`, and here we were checking to see if we had a `scholarship` in cache before grabbing the scholarship with the `$id` we passed. Now, the past scholarship is keyed by using its id so we are always getting the expected scholarship.

#### How should this be reviewed?
Does this return the correct scholarship?

#### Any background context you want to provide?
This was causing the years listed at the top of the Winner's Gallery to be incorrect and make it look like winner's have already been announced for the current scholarship.

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/151418479)

#### Checklist
- [ ] Tested on Whitelabel.
