### PR TITLE
Fix bug where gpa_min is not stored correctly

### DIFF
--- a/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
+++ b/resources/views/admin/scholarship/partials/_form_scholarship.blade.php
@@ -93,7 +93,7 @@
 <div class="form-group">
   {!! Form::label('gpa_min', ' GPA Minimum : ') !!}
   {{-- @TODO: figure out how to put a float here --}}
-  {!! Form::select('gpa_min', array('3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9'), null, ['class' => 'form-control']); !!}
+  {!! Form::select('gpa_min', ['3.0' => 3.0, '3.1' => 3.1, '3.2' => 3.2, '3.3' => 3.3, '3.4' => 3.4, '3.5' => 3.5, '3.6' => 3.6, '3.7' => 3.7, '3.8' => 3.8, '3.9' => 3.9], null, ['class' => 'form-control']); !!}
   {!! errorsFor('gpa_min', $errors); !!}
 </div>
 


### PR DESCRIPTION
#### What's this PR do?
Fixes an error where as the GPA on the scholarship, we were saving the array index instead of the value. So if the 6th GPA in the list was selected (3.5) from the dropdown, it was saved instead as its index (5). When we check if applications submitted had GPAs that were too low, we were comparing to the wrong number (5 instead of 3.5 in this example).

#### How should this be reviewed?
Will this form save the expected GPA value?

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/151532563)

#### Checklist
- [ ] Tested on Whitelabel.
