### PR TITLE
Add index on profile_id to races table

### DIFF
--- a/database/migrations/2017_11_14_170801_add_index_on_profile_id_to_races_table.php
+++ b/database/migrations/2017_11_14_170801_add_index_on_profile_id_to_races_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexOnProfileIdToRacesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('races', function ($table) {
+            $table->index('profile_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('races', function ($table) {
+            $table->dropIndex('races_profile_id_index');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Adds an index on `profile_id` to the `races` table so that queries that use this table will be faster!

#### How should this be reviewed?
Does this index make sense?

#### Any background context you want to provide?
I think this is what was making CSV downloads so slow!

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/152475544)

#### Checklist
- [ ] Tested on Whitelabel.
