### PR TITLE
Put that @endif in the right place

### DIFF
--- a/resources/views/application/partials/_form_application.blade.php
+++ b/resources/views/application/partials/_form_application.blade.php
@@ -69,6 +69,7 @@
       {!! Form::textarea('extra_question_5') !!}
       {!! errorsFor('extra_question_5', $errors); !!}
     </div>
+  @endif
 
   {{-- Activities --}}
   <div class="field-group {{ setInvalidClass('activities', $errors) }}">
@@ -97,8 +98,6 @@
     {!! Form::textarea('essay2') !!}
     {!! errorsFor('essay2', $errors); !!}
   </div>
-
-  @endif
 
   {{-- Upload --}}
   @if ($image_uploads)


### PR DESCRIPTION
#### What's this PR do?
Fixes an error where the `@endif` for the fifth extra question is not after the fifth question, but after a whole bunch of questions!

This caused a bunch of questions to not be displayed unless the fifth extra optional question was used as well.

#### How should this be reviewed?
Is the `@endif` in the right place now?

#### Any background context you want to provide?
![giphy 3](https://user-images.githubusercontent.com/4240292/34619304-b4a5f970-f20f-11e7-8b74-6c785219fadc.gif)

#### Relevant tickets
[Card](https://www.pivotaltracker.com/n/projects/2019429/stories/150050426)

#### Checklist
- [ ] Tested on Whitelabel.
