### PR TITLE
Add command to easily generate a bunch of fake data

### DIFF
--- a/app/Console/Commands/GenerateTestData.php
+++ b/app/Console/Commands/GenerateTestData.php
@@ -33,7 +33,7 @@ class GenerateTestData extends Command
         // plain user
         if (! $type || $type == 'user') {
             $user = factory(User::class, $number)->create()->each(function ($user) {
-                dump('plain user - ' . $user->id);
+                $this->line('plain user - ' . $user->id);
             });
         }
 
@@ -45,14 +45,14 @@ class GenerateTestData extends Command
             }
             $partial_profiles->each(function ($profile) {
                 $profile->race()->save(factory(Race::class)->make());
-                dump('user with partial profile (including race) - ' . $profile->user_id);
+                $this->line('user with partial profile (including race) - ' . $profile->user_id);
             });
         }
 
         // user with partial profile (no race)
         if (! $type || $type == 'partial-profile') {
             $partial_profile_no_race = factory(Profile::class, 'partial', $number)->create();
-            dump('user with partial profile (no race) - ' . $partial_profile_no_race->user_id);
+            $this->line('user with partial profile (no race) - ' . $partial_profile_no_race->user_id);
         }
 
         // user with partial profile and partial app (no race)
@@ -63,7 +63,7 @@ class GenerateTestData extends Command
             }
             $partial_profile_app_no_race->each(function ($profile) {
                 $profile->user->application()->save(factory(Application::class, 'partial')->create());
-                dump('user with partial profile and partial app (no race) - ' . $profile->user_id);
+                $this->line('user with partial profile and partial app (no race) - ' . $profile->user_id);
             });
         }
 
@@ -76,7 +76,7 @@ class GenerateTestData extends Command
             $partial_profile_app->each(function ($profile) {
                 $profile->race()->save(factory(Race::class)->create());
                 $profile->user->application()->save(factory(Application::class, 'partial')->create());
-                dump('user with partial profile and partial app (including race) - ' . $profile->user_id);
+                $this->line('user with partial profile and partial app (including race) - ' . $profile->user_id);
             });
         }
 
@@ -88,7 +88,7 @@ class GenerateTestData extends Command
             }
             $profile->each(function ($profile) {
                 $profile->race()->save(factory(Race::class)->create());
-                dump('user with finished profile (including race) - ' . $profile->user_id);
+                $this->line('user with finished profile (including race) - ' . $profile->user_id);
             });
         }
 
@@ -100,7 +100,7 @@ class GenerateTestData extends Command
             }
             $profile_partial_app->each(function ($profile) {
                 $profile->user->application()->save(factory(Application::class, 'partial')->create());
-                dump('user with finished profile and partial app - ' . $profile->user_id);
+                $this->line('user with finished profile and partial app - ' . $profile->user_id);
             });
         }
 
@@ -114,7 +114,7 @@ class GenerateTestData extends Command
                 $profile->user->application()->save(factory(Application::class, 'submitted')->create());
                 $profile_submitted_app_app = $profile->user->application;
                 $profile_submitted_app_app->recommendation()->save(factory(Recommendation::class, 'request')->create());
-                dump('user with finished profile and submitted app and rec requests - ' . $profile->user_id);
+                $this->line('user with finished profile and submitted app and rec requests - ' . $profile->user_id);
             });
         }
 
@@ -128,7 +128,7 @@ class GenerateTestData extends Command
                 $app->user->application()->save(factory(Application::class, 'submitted')->create());
                 $done_app = $app->user->application;
                 $done_app->recommendation()->save(factory(Recommendation::class, 'request')->create());
-                dump('user with finished profile, completed app, completed rec requests - ' . $app->user_id);
+                $this->line('user with finished profile, completed app, completed rec requests - ' . $app->user_id);
             });
         }
     }

--- a/app/Console/Commands/GenerateTestData.php
+++ b/app/Console/Commands/GenerateTestData.php
@@ -115,7 +115,6 @@ class GenerateTestData extends Command
                 $profile_submitted_app_app = $profile->user->application;
                 $profile_submitted_app_app->recommendation()->save(factory(Recommendation::class, 'request')->create());
                 dump('user with finished profile and submitted app and rec requests - ' . $profile->user_id);
-
             });
         }
 

--- a/app/Console/Commands/GenerateTestData.php
+++ b/app/Console/Commands/GenerateTestData.php
@@ -28,11 +28,18 @@ class GenerateTestData extends Command
     public function fire()
     {
         $number = (int) $this->argument('amount');
-        $type = ($this->argument('type') == 'all') ? null : $this->argument('type');
+        $type = $this->argument('type');
+        if ($type === 'all') {
+            $type = null;
+        }
 
         // plain user
         if (! $type || $type == 'user') {
-            $user = factory(User::class, $number)->create()->each(function ($user) {
+            $users = factory(User::class, $number)->create();
+            if ($number == 1) {
+                $users = collect([$users]);
+            }
+            $users->each(function ($user) {
                 $this->line('plain user - ' . $user->id);
             });
         }
@@ -52,7 +59,12 @@ class GenerateTestData extends Command
         // user with partial profile (no race)
         if (! $type || $type == 'partial-profile') {
             $partial_profile_no_race = factory(Profile::class, 'partial', $number)->create();
-            $this->line('user with partial profile (no race) - ' . $partial_profile_no_race->user_id);
+            if ($number == 1) {
+                $partial_profile_no_race = collect([$partial_profile_no_race]);
+            }
+            $partial_profile_no_race->each(function ($partial) {
+                $this->line('user with partial profile (no race) - ' . $partial->user_id);
+            });
         }
 
         // user with partial profile and partial app (no race)
@@ -84,7 +96,7 @@ class GenerateTestData extends Command
         if (! $type || $type == 'profile-race') {
             $profile = factory(Profile::class, $number)->create();
             if ($number == 1) {
-                $partial_profile_app = collect([$partial_profile_app]);
+                $profile = collect([$profile]);
             }
             $profile->each(function ($profile) {
                 $profile->race()->save(factory(Race::class)->create());
@@ -96,7 +108,7 @@ class GenerateTestData extends Command
         if (! $type || $type == 'profile-partial-app') {
             $profile_partial_app = factory(Profile::class, $number)->create();
             if ($number == 1) {
-                $partial_profile_app = collect([$partial_profile_app]);
+                $profile_partial_app = collect([$profile_partial_app]);
             }
             $profile_partial_app->each(function ($profile) {
                 $profile->user->application()->save(factory(Application::class, 'partial')->create());

--- a/app/Console/Commands/GenerateTestData.php
+++ b/app/Console/Commands/GenerateTestData.php
@@ -2,7 +2,11 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Race;
+use App\Models\User;
 use App\Models\Profile;
+use App\Models\Application;
+use App\Models\Recommendation;
 use Illuminate\Console\Command;
 
 class GenerateTestData extends Command
@@ -12,7 +16,7 @@ class GenerateTestData extends Command
      *
      * @var string
      */
-    protected $name = 'generate:testdata';
+    protected $signature = 'generate:testdata {amount=1} {type=all}';
 
     /**
      * The console command description.
@@ -22,7 +26,110 @@ class GenerateTestData extends Command
     protected $description = 'Make some test data';
 
     public function fire() {
-        $profile = factory(Profile::class)->make();
-        dd($profile);
+        $number = (int) $this->argument('amount');
+        $type = ($this->argument('type') == 'all') ? null : $this->argument('type');
+
+        // plain user
+        if (!$type || $type == 'user') {
+            $user = factory(User::class, $number)->create()->each(function ($user) {
+                dump('plain user - ' . $user->id);
+            });
+        }
+
+        // user with partial profile (including race)
+        if (!$type || $type == 'partial-profile-race') {
+            $partial_profiles = factory(Profile::class, 'partial', $number)->create();
+            if ($number == 1) {
+                $partial_profiles = collect([$partial_profiles]);
+            }
+            $partial_profiles->each(function ($profile) {
+                $profile->race()->save(factory(Race::class)->make());
+                dump('user with partial profile (including race) - ' . $profile->user_id);
+            });
+        }
+
+        // user with partial profile (no race)
+        if (!$type || $type == 'partial-profile') {
+            $partial_profile_no_race = factory(Profile::class, 'partial', $number)->create();
+            dump('user with partial profile (no race) - ' . $partial_profile_no_race->user_id);
+        }
+
+        // user with partial profile and partial app (no race)
+        if (!$type || $type == 'partial-profile-and-app') {
+            $partial_profile_app_no_race = factory(Profile::class, 'partial', $number)->create();
+            if ($number == 1) {
+                $partial_profile_app_no_race = collect([$partial_profile_app_no_race]);
+            }
+            $partial_profile_app_no_race->each(function ($profile) {
+                $profile->user->application()->save(factory(Application::class, 'partial')->create());
+                dump('user with partial profile and partial app (no race) - ' . $profile->user_id);
+            });
+        }
+
+        // user with partial profile and partial app (including race)
+        if (!$type || $type == 'partial-profile-and-app-race') {
+            $partial_profile_app = factory(Profile::class, 'partial', $number)->create();
+            if ($number == 1) {
+                $partial_profile_app = collect([$partial_profile_app]);
+            }
+            $partial_profile_app->each(function ($profile) {
+                $profile->race()->save(factory(Race::class)->create());
+                $profile->user->application()->save(factory(Application::class, 'partial')->create());
+                dump('user with partial profile and partial app (including race) - ' . $profile->user_id);
+            });
+        }
+
+        // user with finished profile (including race)
+        if (!$type || $type == 'profile-race') {
+            $profile = factory(Profile::class, $number)->create();
+            if ($number == 1) {
+                $partial_profile_app = collect([$partial_profile_app]);
+            }
+            $profile->each(function ($profile) {
+                $profile->race()->save(factory(Race::class)->create());
+                dump('user with finished profile (including race) - ' . $profile->user_id);
+            });
+        }
+
+        // user with finished profile and partial app
+        if (!$type || $type == 'profile-partial-app') {
+            $profile_partial_app = factory(Profile::class, $number)->create();
+            if ($number == 1) {
+                $partial_profile_app = collect([$partial_profile_app]);
+            }
+            $profile_partial_app->each(function ($profile) {
+                $profile->user->application()->save(factory(Application::class, 'partial')->create());
+                dump('user with finished profile and partial app - ' . $profile->user_id);
+            });
+        }
+
+        // user with finished profile and submitted app and rec requests
+        if (!$type || $type == 'submitted-app-recs') {
+            $profile_submitted_app = factory(Profile::class, $number)->create();
+            if ($number == 1) {
+                $profile_submitted_app = collect([$profile_submitted_app]);
+            }
+            $profile_submitted_app->each(function ($profile) {
+                $profile->user->application()->save(factory(Application::class, 'submitted')->create());
+                $profile_submitted_app_app = $profile->user->application;
+                $profile_submitted_app_app->recommendation()->save(factory(Recommendation::class, 'request')->create());
+                dump('user with finished profile and submitted app and rec requests - ' . $profile->user_id);
+
+            });
+        }
+
+        // user with finished profile, completed app, completed rec requests
+        if (!$type || $type == 'all-done') {
+            $done = factory(Profile::class, $number)->create();
+            if ($number == 1) {
+                $done = collect([$done]);
+            }
+            $done->each(function ($app) {
+                $app->user->application()->save(factory(Application::class, 'submitted')->create());
+                $done_app = $app->user->application;
+                $done_app->recommendation()->save(factory(Recommendation::class, 'request')->create());
+                dump('user with finished profile, completed app, completed rec requests - ' . $app->user_id);
+            });
+        }
     }
 }

--- a/app/Console/Commands/GenerateTestData.php
+++ b/app/Console/Commands/GenerateTestData.php
@@ -25,19 +25,20 @@ class GenerateTestData extends Command
      */
     protected $description = 'Make some test data';
 
-    public function fire() {
+    public function fire()
+    {
         $number = (int) $this->argument('amount');
         $type = ($this->argument('type') == 'all') ? null : $this->argument('type');
 
         // plain user
-        if (!$type || $type == 'user') {
+        if (! $type || $type == 'user') {
             $user = factory(User::class, $number)->create()->each(function ($user) {
                 dump('plain user - ' . $user->id);
             });
         }
 
         // user with partial profile (including race)
-        if (!$type || $type == 'partial-profile-race') {
+        if (! $type || $type == 'partial-profile-race') {
             $partial_profiles = factory(Profile::class, 'partial', $number)->create();
             if ($number == 1) {
                 $partial_profiles = collect([$partial_profiles]);
@@ -49,13 +50,13 @@ class GenerateTestData extends Command
         }
 
         // user with partial profile (no race)
-        if (!$type || $type == 'partial-profile') {
+        if (! $type || $type == 'partial-profile') {
             $partial_profile_no_race = factory(Profile::class, 'partial', $number)->create();
             dump('user with partial profile (no race) - ' . $partial_profile_no_race->user_id);
         }
 
         // user with partial profile and partial app (no race)
-        if (!$type || $type == 'partial-profile-and-app') {
+        if (! $type || $type == 'partial-profile-and-app') {
             $partial_profile_app_no_race = factory(Profile::class, 'partial', $number)->create();
             if ($number == 1) {
                 $partial_profile_app_no_race = collect([$partial_profile_app_no_race]);
@@ -67,7 +68,7 @@ class GenerateTestData extends Command
         }
 
         // user with partial profile and partial app (including race)
-        if (!$type || $type == 'partial-profile-and-app-race') {
+        if (! $type || $type == 'partial-profile-and-app-race') {
             $partial_profile_app = factory(Profile::class, 'partial', $number)->create();
             if ($number == 1) {
                 $partial_profile_app = collect([$partial_profile_app]);
@@ -80,7 +81,7 @@ class GenerateTestData extends Command
         }
 
         // user with finished profile (including race)
-        if (!$type || $type == 'profile-race') {
+        if (! $type || $type == 'profile-race') {
             $profile = factory(Profile::class, $number)->create();
             if ($number == 1) {
                 $partial_profile_app = collect([$partial_profile_app]);
@@ -92,7 +93,7 @@ class GenerateTestData extends Command
         }
 
         // user with finished profile and partial app
-        if (!$type || $type == 'profile-partial-app') {
+        if (! $type || $type == 'profile-partial-app') {
             $profile_partial_app = factory(Profile::class, $number)->create();
             if ($number == 1) {
                 $partial_profile_app = collect([$partial_profile_app]);
@@ -104,7 +105,7 @@ class GenerateTestData extends Command
         }
 
         // user with finished profile and submitted app and rec requests
-        if (!$type || $type == 'submitted-app-recs') {
+        if (! $type || $type == 'submitted-app-recs') {
             $profile_submitted_app = factory(Profile::class, $number)->create();
             if ($number == 1) {
                 $profile_submitted_app = collect([$profile_submitted_app]);
@@ -119,7 +120,7 @@ class GenerateTestData extends Command
         }
 
         // user with finished profile, completed app, completed rec requests
-        if (!$type || $type == 'all-done') {
+        if (! $type || $type == 'all-done') {
             $done = factory(Profile::class, $number)->create();
             if ($number == 1) {
                 $done = collect([$done]);

--- a/app/Console/Commands/GenerateTestData.php
+++ b/app/Console/Commands/GenerateTestData.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Profile;
+use Illuminate\Console\Command;
+
+class GenerateTestData extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'generate:testdata';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Make some test data';
+
+    public function fire() {
+        $profile = factory(Profile::class)->make();
+        dd($profile);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -29,7 +29,6 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('inspire')
-                 ->hourly();
+
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -29,6 +29,5 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -17,7 +17,7 @@ class Kernel extends ConsoleKernel
         'App\Console\Commands\CustomStylesCommand',
         'App\Console\Commands\TransferWinnersCommand',
         'App\Console\Commands\DatabaseWipeCommand',
-
+        'App\Console\Commands\GenerateTestData',
     ];
 
     /**

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -6,6 +6,8 @@ use App\Models\Race;
 use App\Models\Application;
 use App\Models\Recommendation;
 use App\Models\User;
+use App\Models\Scholarship;
+
 
 /**
 |--------------------------------------------------------------------------
@@ -74,10 +76,10 @@ $factory->define(Race::class, function (Generator $faker) {
 });
 
 // Application ("finished" but not submitted)
-    // scholarship_id
     // user_id
 $factory->define(Application::class, function (Generator $faker) {
     return [
+        'scholarship_id' => Scholarship::getCurrentScholarship()->id,
         'accomplishments' => $faker->paragraphs(4, true),
         'activities' => $faker->paragraph(5),
         'participation' => $faker->paragraph(5),
@@ -91,10 +93,10 @@ $factory->define(Application::class, function (Generator $faker) {
 });
 
 // Submitted Application
-    // scholarship_id
     // user_id
 $factory->defineAs(Application::class, 'submitted', function (Generator $faker) {
     return [
+        'scholarship_id' => Scholarship::getCurrentScholarship()->id,
         'accomplishments' => $faker->paragraphs(4, true),
         'activities' => $faker->paragraph(5),
         'participation' => $faker->paragraph(5),
@@ -109,10 +111,10 @@ $factory->defineAs(Application::class, 'submitted', function (Generator $faker) 
 });
 
 // Completed Application
-    // scholarship_id
     // user_id
 $factory->defineAs(Application::class, 'completed', function (Generator $faker) {
     return [
+        'scholarship_id' => Scholarship::getCurrentScholarship()->id,
         'accomplishments' => $faker->paragraphs(4, true),
         'activities' => $faker->paragraph(5),
         'participation' => $faker->paragraph(5),
@@ -128,10 +130,10 @@ $factory->defineAs(Application::class, 'completed', function (Generator $faker) 
 });
 
 // Partial Application
-    // scholarship_id
     // user_id
 $factory->defineAs(Application::class, 'partial', function (Generator $faker) {
     return [
+        'scholarship_id' => Scholarship::getCurrentScholarship()->id,
         'accomplishments' => $faker->paragraphs(4, true),
         'activities' => $faker->paragraph(5),
     ];

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,12 +1,12 @@
 <?php
 
-use Faker\Generator;
-use App\Models\Profile;
 use App\Models\Race;
-use App\Models\Application;
-use App\Models\Recommendation;
+use Faker\Generator;
 use App\Models\User;
+use App\Models\Profile;
+use App\Models\Application;
 use App\Models\Scholarship;
+use App\Models\Recommendation;
 
 
 /**
@@ -41,9 +41,11 @@ $factory->define(User::class, function (Faker\Generator $faker) {
 });
 
 // Profile Factories
-    // user_id
 $factory->define(Profile::class, function (Generator $faker) {
     return [
+        'user_id' => function () {
+            return factory(User::class)->create()->id;
+        },
         'birthdate' => $faker->dateTimeInInterval($startDate = '-18 years', $interval = '+1 years')->format('Y-m-d'),
         'phone' => $faker->randomNumber(9) . $faker->randomNumber(1),
         'address_street' => $faker->streetAddress(),
@@ -59,9 +61,11 @@ $factory->define(Profile::class, function (Generator $faker) {
 
 
 // Partial Profile factory
-    // user_id
 $factory->defineAs(Profile::class, 'partial', function (Generator $faker) {
     return [
+        'user_id' => function () {
+            return factory(User::class)->create()->id;
+        },
         'birthdate' => $faker->dateTimeInInterval($startDate = '-18 years', $interval = '+1 years')->format('Y-m-d'),
         'phone' => $faker->randomNumber(9) . $faker->randomNumber(1),
     ];
@@ -76,7 +80,6 @@ $factory->define(Race::class, function (Generator $faker) {
 });
 
 // Application ("finished" but not submitted)
-    // user_id
 $factory->define(Application::class, function (Generator $faker) {
     return [
         'scholarship_id' => Scholarship::getCurrentScholarship()->id,
@@ -111,7 +114,6 @@ $factory->defineAs(Application::class, 'submitted', function (Generator $faker) 
 });
 
 // Completed Application
-    // user_id
 $factory->defineAs(Application::class, 'completed', function (Generator $faker) {
     return [
         'scholarship_id' => Scholarship::getCurrentScholarship()->id,
@@ -130,7 +132,6 @@ $factory->defineAs(Application::class, 'completed', function (Generator $faker) 
 });
 
 // Partial Application
-    // user_id
 $factory->defineAs(Application::class, 'partial', function (Generator $faker) {
     return [
         'scholarship_id' => Scholarship::getCurrentScholarship()->id,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,8 +1,8 @@
 <?php
 
 use App\Models\Race;
-use Faker\Generator;
 use App\Models\User;
+use Faker\Generator;
 use App\Models\Profile;
 use App\Models\Application;
 use App\Models\Scholarship;
@@ -10,24 +10,15 @@ use App\Models\Recommendation;
 
 
 /**
-|--------------------------------------------------------------------------
-| Model Factories
-|--------------------------------------------------------------------------
-|
-| Here you may define all of your model factories. Model factories give
-| you a convenient way to create models for testing and seeding your
-| database. Just tell the factory how a default model should look.
-|
-*/
-
-// user
-// user with partial profile (including race)
-// user with partial profile (no race)
-// user with partial profile and partial app
-// user with finished profile
-// user with finished profile and partial app
-// user with finished profile and submitted app and rec requests
-// user with finished profile, completed app, completed rec requests
+ * |--------------------------------------------------------------------------
+ * | Model Factories
+ * |--------------------------------------------------------------------------
+ * |
+ * | Here you may define all of your model factories. Model factories give
+ * | you a convenient way to create models for testing and seeding your
+ * | database. Just tell the factory how a default model should look.
+ * |
+ */
 
 // User Factory
 $factory->define(User::class, function (Faker\Generator $faker) {
@@ -58,7 +49,6 @@ $factory->define(Profile::class, function (Generator $faker) {
         'grade' => $faker->numberBetween(9, 12),
     ];
 });
-
 
 // Partial Profile factory
 $factory->defineAs(Profile::class, 'partial', function (Generator $faker) {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,0 +1,136 @@
+<?php
+use Faker\Generator;
+use App\Models\Profile;
+
+/**
+|--------------------------------------------------------------------------
+| Model Factories
+|--------------------------------------------------------------------------
+|
+| Here you may define all of your model factories. Model factories give
+| you a convenient way to create models for testing and seeding your
+| database. Just tell the factory how a default model should look.
+|
+*/
+
+// user
+// user with partial profile (including race)
+// user with partial profile (no race)
+// user with partial profile and partial app
+// user with finished profile
+// user with finished profile and partial app
+// user with finished profile and submitted app and rec requests
+// user with finished profile, completed app, completed rec requests
+
+
+
+// User Factory
+        // need:
+        // first_name
+        // last_name
+$factory->define(User::class, function (Faker\Generator $faker) {
+    return [
+        'name' => $faker->name,
+        'email' => $faker->safeEmail,
+        'password' => bcrypt(str_random(10)),
+        'remember_token' => str_random(10),
+    ];
+});
+
+// Profile Factory
+    // birthdate
+    // phone
+    // address_street
+    // address_premise
+    // city
+    // state
+    // zip
+    // gender
+    // school
+    // grade
+$factory->define(Profile::class, function (Generator $faker) {
+    return [
+        'birthdate' => $faker->dateTimeInInterval($startDate = '-18 years', $interval = '+1 years')->format('Y-m-d'),
+        'phone' => $faker->phoneNumber,
+        'address_street' => null,
+        'address_premise' => null,
+        'city' => null,
+        'state' => null,
+        'zip' => null,
+        'gender' => null,
+        'school' => null,
+        'grade' => null,
+    ];
+});
+
+
+// Partial Profile factory
+    // birthdate
+    // phone
+
+// Races (goes with profile and partial profile)
+    // profile_id
+    // race
+
+// Applications (need some partial)
+    // scholarship_id
+    // accomplishments
+    // activities
+    // participation
+    // essay1
+    // essay2
+    // hear_about
+    // test_type
+    // test_score
+    // gpa
+
+// submitted app
+    // scholarship_id
+    // accomplishments
+    // activities
+    // participation
+    // essay1
+    // essay2
+    // hear_about
+    // test_type
+    // test_score
+    // gpa
+    // submitted
+
+// completed app
+    // scholarship_id
+    // accomplishments
+    // activities
+    // participation
+    // essay1
+    // essay2
+    // hear_about
+    // test_type
+    // test_score
+    // gpa
+    // submitted
+    // completed
+
+// partial app
+    // scholarship_id
+    // accomplishments
+    // activities
+
+// Recommendation Requests
+    // application_id
+    // first_name
+    // last_name
+    // relationship
+    // phone
+    // email
+
+// Completed Recommendations
+    // application_id
+    // first_name
+    // last_name
+    // relationship
+    // phone
+    // email
+    // rank_character
+    // rank_additional
+    // essay1

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -8,7 +8,6 @@ use App\Models\Application;
 use App\Models\Scholarship;
 use App\Models\Recommendation;
 
-
 /**
  * |--------------------------------------------------------------------------
  * | Model Factories

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,6 +1,11 @@
 <?php
+
 use Faker\Generator;
 use App\Models\Profile;
+use App\Models\Race;
+use App\Models\Application;
+use App\Models\Recommendation;
+use App\Models\User;
 
 /**
 |--------------------------------------------------------------------------
@@ -22,115 +27,139 @@ use App\Models\Profile;
 // user with finished profile and submitted app and rec requests
 // user with finished profile, completed app, completed rec requests
 
-
-
 // User Factory
-        // need:
-        // first_name
-        // last_name
 $factory->define(User::class, function (Faker\Generator $faker) {
     return [
-        'name' => $faker->name,
+        'first_name' => $faker->firstName,
+        'last_name' => $faker->lastName,
         'email' => $faker->safeEmail,
         'password' => bcrypt(str_random(10)),
         'remember_token' => str_random(10),
     ];
 });
 
-// Profile Factory
-    // birthdate
-    // phone
-    // address_street
-    // address_premise
-    // city
-    // state
-    // zip
-    // gender
-    // school
-    // grade
+// Profile Factories
+    // user_id
 $factory->define(Profile::class, function (Generator $faker) {
     return [
         'birthdate' => $faker->dateTimeInInterval($startDate = '-18 years', $interval = '+1 years')->format('Y-m-d'),
-        'phone' => $faker->phoneNumber,
-        'address_street' => null,
-        'address_premise' => null,
-        'city' => null,
-        'state' => null,
-        'zip' => null,
-        'gender' => null,
-        'school' => null,
-        'grade' => null,
+        'phone' => $faker->randomNumber(9) . $faker->randomNumber(1),
+        'address_street' => $faker->streetAddress(),
+        'address_premise' => $faker->randomElement(['', '', $faker->secondaryAddress]),
+        'city' => $faker->city,
+        'state' => $faker->state,
+        'zip' => $faker->randomNumber(5),
+        'gender' => $faker->randomElement(['M', 'F']),
+        'school' => $faker->firstNameFemale . ' ' . $faker->lastName . ' High School',
+        'grade' => $faker->numberBetween(9, 12),
     ];
 });
 
 
 // Partial Profile factory
-    // birthdate
-    // phone
+    // user_id
+$factory->defineAs(Profile::class, 'partial', function (Generator $faker) {
+    return [
+        'birthdate' => $faker->dateTimeInInterval($startDate = '-18 years', $interval = '+1 years')->format('Y-m-d'),
+        'phone' => $faker->randomNumber(9) . $faker->randomNumber(1),
+    ];
+});
 
 // Races (goes with profile and partial profile)
     // profile_id
-    // race
+$factory->define(Race::class, function (Generator $faker) {
+    return [
+        'race' => $faker->randomElement(['White', 'Black/African American', 'Hispanic/Latino/Spanish', 'Asian', 'American Indian or Alaska Native', 'Pacific Islander/Native Hawaiian', 'Other']),
+    ];
+});
 
-// Applications (need some partial)
+// Application ("finished" but not submitted)
     // scholarship_id
-    // accomplishments
-    // activities
-    // participation
-    // essay1
-    // essay2
-    // hear_about
-    // test_type
-    // test_score
-    // gpa
+    // user_id
+$factory->define(Application::class, function (Generator $faker) {
+    return [
+        'accomplishments' => $faker->paragraphs(4, true),
+        'activities' => $faker->paragraph(5),
+        'participation' => $faker->paragraph(5),
+        'essay1' => $faker->paragraphs(6, true),
+        'essay2' => $faker->paragraphs(6, true),
+        'hear_about' => $faker->randomElement(['Online', 'Search Engine', 'Friend', '']),
+        'test_type' => $faker->randomElement(['PSAT', 'ACT', 'SAT (1600)', 'SAT (2400)']),
+        'test_score' => $faker->numberBetween(0, 2400),
+        'gpa' => $faker->randomElement([3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0]),
+    ];
+});
 
-// submitted app
+// Submitted Application
     // scholarship_id
-    // accomplishments
-    // activities
-    // participation
-    // essay1
-    // essay2
-    // hear_about
-    // test_type
-    // test_score
-    // gpa
-    // submitted
+    // user_id
+$factory->defineAs(Application::class, 'submitted', function (Generator $faker) {
+    return [
+        'accomplishments' => $faker->paragraphs(4, true),
+        'activities' => $faker->paragraph(5),
+        'participation' => $faker->paragraph(5),
+        'essay1' => $faker->paragraphs(6, true),
+        'essay2' => $faker->paragraphs(6, true),
+        'hear_about' => $faker->randomElement(['Online', 'Search Engine', 'Friend', '']),
+        'test_type' => $faker->randomElement(['PSAT', 'ACT', 'SAT (1600)', 'SAT (2400)']),
+        'test_score' => $faker->numberBetween(0, 2400),
+        'gpa' => $faker->randomElement([3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0]),
+        'submitted' => 1,
+    ];
+});
 
-// completed app
+// Completed Application
     // scholarship_id
-    // accomplishments
-    // activities
-    // participation
-    // essay1
-    // essay2
-    // hear_about
-    // test_type
-    // test_score
-    // gpa
-    // submitted
-    // completed
+    // user_id
+$factory->defineAs(Application::class, 'completed', function (Generator $faker) {
+    return [
+        'accomplishments' => $faker->paragraphs(4, true),
+        'activities' => $faker->paragraph(5),
+        'participation' => $faker->paragraph(5),
+        'essay1' => $faker->paragraphs(6, true),
+        'essay2' => $faker->paragraphs(6, true),
+        'hear_about' => $faker->randomElement(['Online', 'Search Engine', 'Friend', '']),
+        'test_type' => $faker->randomElement(['PSAT', 'ACT', 'SAT (1600)', 'SAT (2400)']),
+        'test_score' => $faker->numberBetween(0, 2400),
+        'gpa' => $faker->randomElement([3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0]),
+        'submitted' => 1,
+        'completed' => 1,
+    ];
+});
 
-// partial app
+// Partial Application
     // scholarship_id
-    // accomplishments
-    // activities
+    // user_id
+$factory->defineAs(Application::class, 'partial', function (Generator $faker) {
+    return [
+        'accomplishments' => $faker->paragraphs(4, true),
+        'activities' => $faker->paragraph(5),
+    ];
+});
 
 // Recommendation Requests
     // application_id
-    // first_name
-    // last_name
-    // relationship
-    // phone
-    // email
+$factory->defineAs(Recommendation::class, 'request', function (Generator $faker) {
+    return [
+        'first_name' => $faker->firstName(),
+        'last_name' => $faker->lastName,
+        'relationship' => $faker->randomElement(['Teacher', 'Coach', 'Mentor', 'Band Director', 'Club Sponsor', 'Parent']),
+        'phone' => $faker->randomNumber(9) . $faker->randomNumber(1),
+        'email' => $faker->safeEmail,
+    ];
+});
 
 // Completed Recommendations
     // application_id
-    // first_name
-    // last_name
-    // relationship
-    // phone
-    // email
-    // rank_character
-    // rank_additional
-    // essay1
+$factory->defineAs(Recommendation::class, 'complete', function (Generator $faker) {
+    return [
+        'first_name' => $faker->firstName(),
+        'last_name' => $faker->lastName,
+        'relationship' => $faker->randomElement(['Teacher', 'Coach', 'Mentor', 'Band Director', 'Club Sponsor', 'Parent']),
+        'phone' => $faker->randomNumber(9) . $faker->randomNumber(1),
+        'email' => $faker->safeEmail,
+        'rank_character' => $faker->randomElement(Recommendation::getRankValues()),
+        'rank_additional' => $faker->randomElement(Recommendation::getRankValues()),
+        'essay1' => $faker->paragraph(5),
+    ];
+});


### PR DESCRIPTION
#### What's this PR do?
:weight_lifting_woman: Add a bunch of model factories to create the fake data in finished and partially finished states.

✍️ Adds an artisan command to create all or one type of data. If run with no arguments, creates 1 of each option. Otherwise, creates the specified number of the given type (or everything if no type given). The command uses the factories to create the data and relates them in different ways given the scenario. The different types are:

- plain user  - `user`
- user with partial profile (including race) - `partial-profile-race`
- user with partial profile (no race) - `partial-profile`
- user with partial profile and partial app (no race) - `partial-profile-and-app`
- user with partial profile and partial app (including race) - `partial-profile-and-app-race`
- user with finished profile (including race) - `profile-race`
- user with finished profile and partial app - `profile-partial-app`
- user with finished profile and submitted app and rec requests - `submitted-app-recs`
- user with finished profile, completed app, completed rec requests - `all-done`

#### How should this be reviewed?
Do the factories make sense? Is there anything that would make the command more useful?

#### Any background context you want to provide?
This will allow admins to generate large amounts of test data very easily!!

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/154258102)

#### Checklist
- [ ] Tested on Whitelabel.
