### PR TITLE
Remove placeholder key

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -91,7 +91,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomString'),
+    'key' => env('APP_KEY'),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
#### What's this PR do?
Removes the placeholder key! In the event that we do not set `APP_KEY` in the `.env` file, we would rather get errors and fix it than use a key that is public.

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Tested on Whitelabel.
