### PR TITLE
Send group emails in the background

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,5 @@
 preset: laravel
 
-linting: true
-
 disabled:
  - concat_without_spaces
  - no_useless_return

--- a/app/Jobs/Job.php
+++ b/app/Jobs/Job.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+
+abstract class Job
+{
+    /*
+    |--------------------------------------------------------------------------
+    | Queueable Jobs
+    |--------------------------------------------------------------------------
+    |
+    | This job base class provides a central location to place any logic that
+    | is shared across all of your jobs. The trait included with the class
+    | provides access to the "onQueue" and "delay" queue helper methods.
+    |
+    */
+
+    use Queueable;
+}

--- a/app/Jobs/SendGroupEmail.php
+++ b/app/Jobs/SendGroupEmail.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Jobs;
+
+use Mail;
+use App\Jobs\Job;
+use App\Models\Email;
+use App\Models\Export;
+use App\Models\Scholarship;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendGroupEmail extends Job implements ShouldQueue
+{
+    use InteractsWithQueue, SerializesModels;
+
+    protected $exportName;
+    protected $exportFunction;
+    protected $adminEmail;
+
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($exportName, $exportFunction, $adminEmail)
+    {
+        // $this->exportName = $exportName;
+        // $this->exportFunction = $exportFunction;
+        // $this->adminEmail = $adminEmail;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(Export $export)
+    {
+        info('Sending Group Email: ' . $this->exportFunction);
+
+        // Run the export query
+        $query_result = $export->{$this->exportFunction}();
+
+        $email = new Email();
+
+        // For each result, construct and send the email
+        $tokens = [];
+        foreach ($query_result as $row) {
+            // Grab the email address
+            $send_to = $row->email;
+
+            // Define row specific tokens
+            if (isset($row->first_name)) {
+                $tokens[':first_name:'] = $row->first_name;
+            }
+            if (isset($row->last_name)) {
+                $tokens[':last_name:'] = $row->last_name;
+            }
+
+            // Send it by passing in key, recipient, to, and extra tokens
+            // $messageToSend = Email::where('key', '=', $this->exportName)->firstOrFail();
+            $email->sendEmail($this->exportName, 'group', $send_to, $tokens);
+
+            info($this->exportFunction . ' email sent to: ' . $send_to);
+        }
+
+        // Notify us that the emails have all been queued
+        info('DONE Group Emails all queued: ' . $this->exportFunction);
+        Mail::raw('DONE Queuing Group Email: ' . $this->exportFunction, function ($message) {
+            // $message->to($this->adminEmail);
+            $message->subject('Done Queuing Group Email: ' . $this->exportFunction);
+            // $message->from(Scholarship::getCurrentScholarship()->email_from_address, Scholarship::getCurrentScholarship()->email_from_name);
+        });
+    }
+}

--- a/app/Jobs/SendGroupEmail.php
+++ b/app/Jobs/SendGroupEmail.php
@@ -27,9 +27,9 @@ class SendGroupEmail extends Job implements ShouldQueue
      */
     public function __construct($exportName, $exportFunction, $adminEmail)
     {
-        // $this->exportName = $exportName;
-        // $this->exportFunction = $exportFunction;
-        // $this->adminEmail = $adminEmail;
+        $this->exportName = $exportName;
+        $this->exportFunction = $exportFunction;
+        $this->adminEmail = $adminEmail;
     }
 
     /**
@@ -61,7 +61,6 @@ class SendGroupEmail extends Job implements ShouldQueue
             }
 
             // Send it by passing in key, recipient, to, and extra tokens
-            // $messageToSend = Email::where('key', '=', $this->exportName)->firstOrFail();
             $email->sendEmail($this->exportName, 'group', $send_to, $tokens);
 
             info($this->exportFunction . ' email sent to: ' . $send_to);
@@ -70,9 +69,9 @@ class SendGroupEmail extends Job implements ShouldQueue
         // Notify us that the emails have all been queued
         info('DONE Group Emails all queued: ' . $this->exportFunction);
         Mail::raw('DONE Queuing Group Email: ' . $this->exportFunction, function ($message) {
-            // $message->to($this->adminEmail);
+            $message->to($this->adminEmail);
             $message->subject('Done Queuing Group Email: ' . $this->exportFunction);
-            // $message->from(Scholarship::getCurrentScholarship()->email_from_address, Scholarship::getCurrentScholarship()->email_from_name);
+            $message->from(Scholarship::getCurrentScholarship()->email_from_address, Scholarship::getCurrentScholarship()->email_from_name);
         });
     }
 }

--- a/app/Jobs/SendGroupEmail.php
+++ b/app/Jobs/SendGroupEmail.php
@@ -3,7 +3,6 @@
 namespace App\Jobs;
 
 use Mail;
-use App\Jobs\Job;
 use App\Models\Email;
 use App\Models\Export;
 use App\Models\Scholarship;
@@ -18,7 +17,6 @@ class SendGroupEmail extends Job implements ShouldQueue
     protected $exportName;
     protected $exportFunction;
     protected $adminEmail;
-
 
     /**
      * Create a new job instance.

--- a/config/app.php
+++ b/config/app.php
@@ -108,7 +108,7 @@ return [
     |
     */
 
-    'log' => 'daily',
+    'log' => env('APP_LOG', 'daily'),
 
     /*
     |--------------------------------------------------------------------------
@@ -147,6 +147,7 @@ return [
         'Illuminate\View\ViewServiceProvider',
         'Collective\Html\HtmlServiceProvider',
         'Illuminate\Broadcasting\BroadcastServiceProvider',
+        'Illuminate\Bus\BusServiceProvider',
 
         /*
          * Application Service Providers...


### PR DESCRIPTION
### What's this PR do?
This adds a Laravel job to handle the sending of group emails in the background. Now, when an admin sends a group email, all that has to happen in realtime is telling the job which category of group email we are sending! We also include the email address of the admin and notify them via email once the job has processed all of the group emails. None of the logic of sending the group emails has changed here, it just happens in a different place now.

### How should this be reviewed?
Wasn't sure the best way to notify admins that the emails are ready to be sent. I updated the flash message to say `We will send an email to everyone!` (instead of saying that we did). Once the job builds all the emails and calls `sendEmail` on them, the admin gets an email telling them that the emails have all been queued. But at that point, the emails have been added to the queue to be sent, but haven't necessarily sent yet. I guess that's okay though, because in that same situation we used to tell them `Got an email sent to everyone!`.

### Any background context you want to provide?
#### Current State
![image](https://user-images.githubusercontent.com/4240292/43929393-a524bf2a-9be9-11e8-8b1c-673334328e7f.png)

On the above page, we allow admins to download data about and send emails to different groups of users. For more information on these groups, see [this wiki page](https://github.com/DoSomething/longshot/wiki/Group-Emails-and-CSV-Exports-(Admin)). Admins write the email subjects and bodies at `/admin/email`. Currently, when they click `Send Email`, we [build all the emails and push the mail onto the queue to actually be sent](https://github.com/DoSomething/longshot/blob/master/app/models/Email.php#L20-L56). When building the emails, there may be tens of thousands of users to iterate through and we have to do some string replacement since we allow the use of personalized tokens (like first name) in emails. 

Because all of that happened in real-time, after sending an email this page would often time out, because it didn't get through all the email building fast enough! This was a bad user experience because it was hard to tell if the emails sent at all, and led to us having to check in Mandrill if they all sent, which is a pain.

### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/158995490)

#### Checklist
- [ ] Tested on Whitelabel.
