### PR TITLE
Add searching by email

### DIFF
--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -154,7 +154,7 @@ class AdminController extends \Controller
 
         $applicants = $query->get();
 
-        return view('admin.applications.index', compact('applicants'));
+        return view('admin.applications.index', compact('applicants', 'search'));
     }
 
     /**

--- a/app/Http/Controllers/admin/AdminController.php
+++ b/app/Http/Controllers/admin/AdminController.php
@@ -94,9 +94,7 @@ class AdminController extends \Controller
         $filter_by = $request->input('filter_by');
         $direction = $request->input('direction');
 
-        $query = DB::table('users');
-
-        $query = $this->applicantBaseQuery($query);
+        $query = $this->applicantBaseQuery();
         $query->leftJoin('role_user', 'users.id', '=', 'role_user.user_id')
                   ->whereNull('role_user.role_id');
 
@@ -143,14 +141,16 @@ class AdminController extends \Controller
         return view('admin.applications.index', compact('applicants'));
     }
 
+    /**
+     * Find applicant based on last name or email
+     */
     public function search(Request $request)
     {
-        $name = $request->input('search');
+        $search = $request->input('search');
 
-        $query = DB::table('users');
-        $query = $this->applicantBaseQuery($query);
-
-        $query->where('last_name', 'LIKE', '%'.$name.'%');
+        $query = $this->applicantBaseQuery()
+                        ->where('last_name', 'LIKE', '%'.$search.'%')
+                        ->orWhere('email', 'LIKE', '%'.$search.'%');
 
         $applicants = $query->get();
 
@@ -353,9 +353,10 @@ class AdminController extends \Controller
     /**
      * Helper function to select/join for the admin index table.
      */
-    public static function applicantBaseQuery($query)
+    public static function applicantBaseQuery()
     {
-        $query->select('users.id', 'users.first_name', 'users.last_name', 'users.email',
+        $query = DB::table('users')
+          ->select('users.id', 'users.first_name', 'users.last_name', 'users.email',
                    'profiles.state', 'profiles.gender',
                    'applications.submitted', 'applications.completed', 'applications.gpa',
                    'ratings.rating')

--- a/resources/views/admin/applications/index.blade.php
+++ b/resources/views/admin/applications/index.blade.php
@@ -12,7 +12,12 @@
 
         {!! Form::open(['route' => 'search', 'class' => 'navbar-form navbar-right']) !!}
           <div class="input-group">
-            {!! Form::text('search', NULL, ['class' => 'form-control', 'placeholder' => 'last name']) !!}
+            @if (isset($search))
+                {!! Form::text('search', $search, ['class' => 'form-control', 'placeholder' => 'last name or email']) !!}
+            @else
+                {!! Form::text('search', NULL, ['class' => 'form-control', 'placeholder' => 'last name or email']) !!}
+            @endif
+
             <div class="input-group-btn">
               <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-search"></span> Search</button>
             </div>

--- a/resources/views/admin/applications/index.blade.php
+++ b/resources/views/admin/applications/index.blade.php
@@ -12,12 +12,7 @@
 
         {!! Form::open(['route' => 'search', 'class' => 'navbar-form navbar-right']) !!}
           <div class="input-group">
-            @if (isset($search))
-                {!! Form::text('search', $search, ['class' => 'form-control', 'placeholder' => 'last name or email']) !!}
-            @else
-                {!! Form::text('search', NULL, ['class' => 'form-control', 'placeholder' => 'last name or email']) !!}
-            @endif
-
+            {!! Form::text('search', isset($search) ? $search : NULL, ['class' => 'form-control', 'placeholder' => 'last name or email']) !!}
             <div class="input-group-btn">
               <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-search"></span> Search</button>
             </div>


### PR DESCRIPTION
#### What's this PR do?
Search by email demo:
![longshot_search](https://user-images.githubusercontent.com/4240292/44167811-0c763200-a084-11e8-9263-5df5b44e91d4.gif)

Added:
- Added `email` to the search query so admins can now search by email and last name
- Updated `applicantBaseQuery()`
    - We were always doing: `DB::table('users')` and then passing it into the function, so I moved that piece to happen inside the function itself to make it more readable
- When an admin searches, pass what they searched for into the view so that we can persist it inside the search box when we show the results. Previously, the search term did not appear with the results which I thought was confusing.

#### How should this be reviewed?
Are you able to search by email address now and is this a better admin experience?

#### Any background context you want to provide?
Previously, admins could only search by last name, which isn't great when someone has spelled their last name wrong or when several applicants have the same last name. 

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/158995413)

#### Checklist
- [ ] Tested on Whitelabel.
