### PR TITLE
Adding failed jobs table migration

### DIFF
--- a/database/migrations/2018_09_11_170552_create_failed_jobs_table.php
+++ b/database/migrations/2018_09_11_170552_create_failed_jobs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateFailedJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('failed_jobs');
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This adds a failed jobs table to the database so we can keep track of emails that fail to be sent. Adding this table fixed the issue with sending emails on the production Footlocker server after going through the steps listed here - https://laravel.com/docs/5.7/queues#running-the-queue-worker

#### How should this be reviewed?


#### Any background context you want to provide?


#### Relevant tickets
https://github.com/DoSomething/devops/issues/441

#### Checklist
- [x] Tested on Whitelabel.
