### PR TITLE
Add TrustedProxy for Heroku.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends HttpKernel
         'Illuminate\Session\Middleware\StartSession',
         'Illuminate\View\Middleware\ShareErrorsFromSession',
         'App\Http\Middleware\VerifyCsrfToken',
+        'App\Http\Middleware\TrustProxies',
     ];
 
     /**

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Aurora\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Fideloper\Proxy\TrustProxies as Middleware;
+
+class TrustProxies extends Middleware
+{
+    /**
+     * The trusted proxies for this application,
+     * sourced from 'config/trustedproxy.php'.
+     *
+     * @var array
+     */
+    protected $proxies;
+
+    /**
+     * The current proxy header mappings.
+     *
+     * @var array
+     */
+    protected $headers = [
+        Request::HEADER_FORWARDED => null, // Not set on AWS or Heroku.
+        Request::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
+        Request::HEADER_X_FORWARDED_HOST => null, // Not set on AWS or Heroku.
+        Request::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
+        Request::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
+    ];
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 		"league/flysystem-aws-s3-v3": "~1.0",
 		"predis/predis": "~1.0",
 		"league/csv": "^9.0",
-		"aws/aws-sdk-php": "~3.0"
+		"aws/aws-sdk-php": "~3.0",
+		"fideloper/proxy": "^3.3"
 	},
 	"require-dev": {
 		"fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5bbaf49d82007fbb6d2e4cdab5a6183",
+    "content-hash": "fe54d6afa1c09710d3b4451a913f86b8",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.71.6",
+            "version": "3.72.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "59e2efc13ce4c8d58351cda27696c16e15662f8c"
+                "reference": "990fc104600d0da59b0229e04c008abd16c5d0ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/59e2efc13ce4c8d58351cda27696c16e15662f8c",
-                "reference": "59e2efc13ce4c8d58351cda27696c16e15662f8c",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/990fc104600d0da59b0229e04c008abd16c5d0ee",
+                "reference": "990fc104600d0da59b0229e04c008abd16c5d0ee",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-11-14T22:36:13+00:00"
+            "time": "2018-11-15T23:57:11+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -716,6 +716,63 @@
                 "parser"
             ],
             "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "fideloper/proxy",
+            "version": "3.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fideloper/TrustedProxy.git",
+                "reference": "9cdf6f118af58d89764249bbcc7bb260c132924f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fideloper/TrustedProxy/zipball/9cdf6f118af58d89764249bbcc7bb260c132924f",
+                "reference": "9cdf6f118af58d89764249bbcc7bb260c132924f",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "~5.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "illuminate/http": "~5.0",
+                "mockery/mockery": "~0.9.3",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Fideloper\\Proxy\\TrustedProxyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fideloper\\Proxy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Fidao",
+                    "email": "fideloper@gmail.com"
+                }
+            ],
+            "description": "Set trusted proxies for Laravel",
+            "keywords": [
+                "load balancing",
+                "proxy",
+                "trusted proxy"
+            ],
+            "time": "2017-06-15T17:19:42+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -3366,16 +3423,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.9",
+            "version": "0.9.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856"
+                "reference": "4876fc0c7d9e5da49712554a35c94d84ed1e9ee5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
-                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/4876fc0c7d9e5da49712554a35c94d84ed1e9ee5",
+                "reference": "4876fc0c7d9e5da49712554a35c94d84ed1e9ee5",
                 "shasum": ""
             },
             "require": {
@@ -3427,7 +3484,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-02-28T12:52:32+00:00"
+            "time": "2018-11-13T20:50:16+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,27 @@
+<?php
+
+// Pre-process any comma-separated values into an array.
+$trustedProxies = env('TRUSTED_PROXY_IP_ADDRESSES');
+if (str_contains($trustedProxies, ',')) {
+    $trustedProxies = explode(',', $trustedProxies);
+}
+
+return [
+    /*
+     * Set trusted proxy IP addresses.
+     *
+     * Both IPv4 and IPv6 addresses are supported, along with CIDR notation.
+     *
+     * The "*" character is syntactic sugar within TrustedProxy to trust any proxy
+     * that connects directly to your server,a requirement when you cannot know the
+     * address of your proxy (e.g. if using Rackspace balancers).
+     *
+     * The "**" character is syntactic sugar within TrustedProxy to trust not just any
+     * proxy that connects directly to your server, but also proxies that connect to
+     * those proxies, and all the way back until you reach the original source IP.
+     *
+     * It will mean that $request->getClientIp() always gets the originating client IP,
+     * no matter how many proxies that client's request has subsequently passed through.
+     */
+    'proxies' => $trustedProxies,
+];


### PR DESCRIPTION
#### What's this PR do?
This pull request adds the [TrustedProxy](https://github.com/fideloper/TrustedProxy) middleware to this application so that we can properly use SSL on Heroku.

#### How should this be reviewed?
I'll deploy this to our QA environment to double-check this sorts things out.

#### Any background context you want to provide?
N/A

#### Relevant tickets
References DoSomething/infrastructure#49.

#### Checklist
- [ ] Tested on Whitelabel.