### PR TITLE
Fix some bugs with uploading images to S3.

### DIFF
--- a/app/Scholarship/Repositories/SettingRepository.php
+++ b/app/Scholarship/Repositories/SettingRepository.php
@@ -83,10 +83,12 @@ class SettingRepository
      */
     public function moveImage($key)
     {
-        $extension = Input::file($key)->guessExtension();
+        $file = file_get_contents(Input::file($key)->getRealPath());
 
+        $extension = Input::file($key)->guessExtension();
         $path = uploadedContentPath('images').'/'.snakeCaseToKebabCase($key).'.'.$extension;
-        Storage::put($path, Input::file($key), 'public');
+
+        Storage::put($path, $file, 'public');
 
         return $path;
     }

--- a/app/Scholarship/Repositories/SettingRepository.php
+++ b/app/Scholarship/Repositories/SettingRepository.php
@@ -3,6 +3,7 @@
 namespace Scholarship\Repositories;
 
 use Cache;
+use Storage;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Input;
 

--- a/app/Scholarship/helpers.php
+++ b/app/Scholarship/helpers.php
@@ -161,7 +161,7 @@ function uploadedContentPath($type = '')
 /**
  * Prepare URL for an image stored locally or in S3.
  */
-function asset_url($path, $fallback)
+function asset_url($path, $fallback = null)
 {
     if (! $path) {
         return $fallback;

--- a/resources/views/admin/settings/partials/_form_settings.blade.php
+++ b/resources/views/admin/settings/partials/_form_settings.blade.php
@@ -52,7 +52,7 @@
 
       @if (!empty($setting->value))
         <div class="image-holder">
-          <img src="{{ $setting->value }}" alt="uploaded image">
+          <img src="{{ asset_url($setting->value) }}" alt="uploaded image">
         </div>
         @if ($setting->key === 'background_image')
           {!! Form::label('Remove?') !!}


### PR DESCRIPTION
#### What's this PR do?
Whoops! Forgot to import the `Storage` facade in #917, so this was erroring out:

> Nov 16 16:16:30 dosomething-longshot-qa app/web.1:  [16-Nov-2018 21:16:30 UTC] [2018-11-16 21:16:30] production.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Class 'Scholarship\Repositories\Storage' not found in /app/app/Scholarship/Repositories/SettingRepository.php:88 

I also double-checked [the documentation](https://laravel.com/docs/5.2/filesystem#basic-usage) and realized I had been using `Storage::put` incorrectly (by passing the "file" object instead of contents as a string). Finally, this PR uses the `asset_url` helper to display these images in the admin panel too!

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
N/A

#### Relevant tickets
References DoSomething/infrastructure#49.

#### Checklist
- [x] Tested on Whitelabel.