### PR TITLE
Install GD extension on Heroku.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 		"league/csv": "^9.0",
 		"aws/aws-sdk-php": "~3.0",
 		"fideloper/proxy": "^3.3",
-		"intervention/image": "^2.4"
+		"intervention/image": "^2.4",
+    "ext-gd": "*"
 	},
 	"require-dev": {
 		"fzaninotto/faker": "~1.4",


### PR DESCRIPTION
#### What's this PR do?
It turns out the `Image::make` call in #920 (for returning an image from S3 without saving a temporary file to disk) [requires the GD PHP extension](https://papertrailapp.com/systems/longshot-hrblock/events?focus=1004118568080257026&selected=1004118568080257026). This pull request adds it.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
I've tested this on my local Homestead, which has the GD extension installed.

#### Relevant tickets
References DoSomething/infrastructure#49.

#### Checklist
- [ ] Tested on Whitelabel.