### PR TITLE
Require the New Relic PHP agent.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 		"aws/aws-sdk-php": "~3.0",
 		"fideloper/proxy": "^3.3",
 		"intervention/image": "^2.4",
-    "ext-gd": "*"
+    "ext-gd": "*",
+    "ext-newrelic": "*"
 	},
 	"require-dev": {
 		"fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "02c132f4de47433863e66df77ab89bd5",
+    "content-hash": "f0526cafee9a30699eba5da3ddbe05ff",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.76.0",
+            "version": "3.77.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "ae331953146493aa71853b5c675f0b7b48c9c952"
+                "reference": "a29f5d77910d04fe9045abc89d9f0411977c44d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ae331953146493aa71853b5c675f0b7b48c9c952",
-                "reference": "ae331953146493aa71853b5c675f0b7b48c9c952",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a29f5d77910d04fe9045abc89d9f0411977c44d3",
+                "reference": "a29f5d77910d04fe9045abc89d9f0411977c44d3",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-11-27T05:14:58+00:00"
+            "time": "2018-11-28T00:16:37+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -4911,7 +4911,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~7.1.0",
-        "ext-gd": "*"
+        "ext-gd": "*",
+        "ext-newrelic": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request requires the [`ext-newrelic` extension](https://devcenter.heroku.com/articles/php-support#php-7-1) in Longshot, so we can get this set up properly on Heroku (which has some frustrating gotchas when using the add-on as we've done elsewhere, described in DoSomething/infrastructure#59).

This will now require the New Relic agent to be installed on our locals as well (since Composer checks for `ext-*` on installs), which is probably a good idea for dev-prod parity anyways. Add in Homestead's `after.sh` & run a `homestead provision` (will update docs as well!):

```sh
# Install New Relic agent:
sudo sh -c "echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' > /etc/apt/sources.list.d/newrelic.list"
wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
sudo apt-get update

sudo DEBIAN_FRONTEND=noninteractive apt-get -y install newrelic-php5
```

#### How should this be reviewed?
We can see whether this installs the extension as it should when deployed to Longshot QA.

#### Any background context you want to provide?
N/A

#### Relevant tickets
References DoSomething/infrastructure#49.

#### Checklist
- [ ] Tested on Whitelabel.