### PR TITLE
Add a configuration setting for enabling/disabling New Relic.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ web: vendor/bin/heroku-php-nginx -C nginx.conf public/
 
 release: php artisan migrate --force
 
-queue: php artisan queue:listen sqs --tries=3 --sleep=5
+queue: php -c public/.user.ini artisan queue:listen sqs --tries=3 --sleep=5

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,7 +1,6 @@
 upload_max_filesize = 10M
 post_max_size = 10M
 
-# Configure New Relic PHP agent:
+# Custom New Relic settings, in addition to Heroku's
+# defaults, which are set here <https://git.io/fpazT>:
 newrelic.enabled = "${NEW_RELIC_ENABLED}"
-newrelic.appname = "${NEW_RELIC_APP_NAME}"
-newrelic.license = "${NEW_RELIC_LICENSE_KEY}"

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,2 +1,7 @@
 upload_max_filesize = 10M
 post_max_size = 10M
+
+# Configure New Relic PHP agent:
+newrelic.enabled = "${NEW_RELIC_ENABLED}"
+newrelic.appname = "${NEW_RELIC_APP_NAME}"
+newrelic.license = "${NEW_RELIC_LICENSE_KEY}"


### PR DESCRIPTION
#### What's this PR do?
We want the New Relic agent to be included in this application's builds, since those get promoted between environments (and so if it doesn't exist in QA, it'd never exist in production). However, if we don't disable the New Relic agent on production, we'll get drowned in alerting! Oy!

This pull request sets `newrelic.enabled` based on the `$NEW_RELIC_ENABLED` enviroment variable so we can selectively enable or disable this in different environments, and updates the command for the queue process to read this INI file too. I've tested this alongside DoSomething/infrastructure#59 on Longshot QA & all seems well – next step is testing on prod!

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Once this is sorted out, I'll clean up how we handle this in other apps as well.

#### Relevant tickets
References DoSomething/infrastructure#49.

#### Checklist
- [ ] Tested on Whitelabel.