### PR TITLE
Lock Node to known working version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "babel-preset-react": "^6.11.1",
     "susy": "^2.2.2"
   },
+  "engines": {
+    "node": "10.14.1"
+  },
   "scripts": {
     "start": "gulp watch",
     "postinstall": "bower install",


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes builds for this application, which were [failing](https://dashboard.heroku.com/apps/longshot-qa/activity/builds/ad305580-60e1-4a39-9c9a-6738986ff585) because of an issue with Gulp introduced in Node 10.15.0. By pinning to the [previously working](https://dashboard.heroku.com/apps/longshot-qa/activity/builds/69196f81-a52b-4b2a-a7cf-af631bebaa7f) Node LTS version (10.14.1), builds [are back to "green"](https://dashboard.heroku.com/apps/longshot-qa/activity/releases/80354e64-a251-4429-9323-4673717a735e).

#### How should this be reviewed?
Follow the links to see the builds before and after this quick fix.

#### Any background context you want to provide?
We should update the tooling in this application, since its Bower + Gulp toolchain is outdated and not something we use or support on any of our other applications.

#### Relevant tickets
N/A

#### Checklist
- [ ] Tested on Whitelabel.