### PR TITLE
Fix `wipe:applicants` command to preserve admins and auto_increment

### DIFF
--- a/app/Console/Commands/DatabaseWipeCommand.php
+++ b/app/Console/Commands/DatabaseWipeCommand.php
@@ -47,12 +47,12 @@ class DatabaseWipeCommand extends Command
      */
     public function fire()
     {
-        if (! $this->confirm('Did you transfer the winners data to the winners table? [y|n]')) {
-            return $this->error('Please run artisan transfer:winners command!');
+        if (! $this->confirm('If this is Footlocker External, is the winner gallery finished? [y|n]')) {
+            return $this->error('Please award scholarships before running!');
         }
 
-        if (! $this->confirm('Did you run a dump and back up the current database? [y|n]')) {
-            return $this->error('Please back up the current database before proceeding!');
+        if (! $this->confirm('Did you take a snapshot of the current database? [y|n]')) {
+            return $this->error('Please take a snapshot of the current database before proceeding!');
         }
 
         // Get the admins from the Users table.

--- a/app/Console/Commands/DatabaseWipeCommand.php
+++ b/app/Console/Commands/DatabaseWipeCommand.php
@@ -70,6 +70,19 @@ class DatabaseWipeCommand extends Command
             })
             ->delete();
 
+        // Do a check to make sure we have the expected number of admins
+        $ids = DB::table('role_user')->pluck('user_id');
+        $emails = DB::table('users')->whereIn('id', $ids)->pluck('email');
+        if (count($ids) === count($emails)) {
+            $this->line('Correct number of '.count($ids).' admins found.');
+        } else {
+            $this->line('WARNING! NUMBER OF ADMIN ASSIGNMENTS DOES NOT MATCH NUMBER OF ADMIN USERS.');
+        }
+        $this->line('The admins are: ');
+        foreach($emails as $email) {
+            $this->line($email);
+        }
+
         $this->info('All set! We successfully killed all the user data with fire and kept existing admins.');
     }
 }

--- a/app/Console/Commands/DatabaseWipeCommand.php
+++ b/app/Console/Commands/DatabaseWipeCommand.php
@@ -48,7 +48,7 @@ class DatabaseWipeCommand extends Command
             return $this->error('Please take a snapshot of the current database before proceeding!');
         }
 
-        // Clear out database tables.
+        // Clear out database tables with applicant data (except for winners).
         DB::table('applications')->delete();
         DB::table('nominations')->delete();
         DB::table('profiles')->delete();
@@ -56,9 +56,7 @@ class DatabaseWipeCommand extends Command
         DB::table('ratings')->delete();
         DB::table('recommendations')->delete();
         DB::table('recommendation_tokens')->delete();
-        if ((Schema::hasTable('failed_jobs'))) {
-            DB::table('failed_jobs')->delete();
-        }
+        DB::table('failed_jobs')->delete();
         DB::table('password_resets')->delete();
 
         // Delete users who are not admins

--- a/app/Console/Commands/DatabaseWipeCommand.php
+++ b/app/Console/Commands/DatabaseWipeCommand.php
@@ -3,15 +3,8 @@
 namespace App\Console\Commands;
 
 use DB;
-use App\Models\Race;
 use App\Models\User;
-use App\Models\Rating;
-use App\Models\Profile;
-use App\Models\Nomination;
-use App\Models\Application;
-use App\Models\Recommendation;
 use Illuminate\Console\Command;
-use App\Models\RecommendationToken;
 use Illuminate\Support\Facades\Schema;
 
 class DatabaseWipeCommand extends Command

--- a/app/Console/Commands/DatabaseWipeCommand.php
+++ b/app/Console/Commands/DatabaseWipeCommand.php
@@ -79,7 +79,7 @@ class DatabaseWipeCommand extends Command
             $this->line('WARNING! NUMBER OF ADMIN ASSIGNMENTS DOES NOT MATCH NUMBER OF ADMIN USERS.');
         }
         $this->line('The admins are: ');
-        foreach($emails as $email) {
+        foreach ($emails as $email) {
             $this->line($email);
         }
 

--- a/app/Console/Commands/DatabaseWipeCommand.php
+++ b/app/Console/Commands/DatabaseWipeCommand.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use DB;
 use App\Models\User;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Schema;
 
 class DatabaseWipeCommand extends Command
 {

--- a/database/migrations/2014_09_24_151910_add_complete_field.php
+++ b/database/migrations/2014_09_24_151910_add_complete_field.php
@@ -12,7 +12,8 @@ class AddCompleteField extends Migration
     public function up()
     {
         Schema::table('applications', function ($table) {
-            $table->tinyInteger('complete')->index()->nullable()->after('gpa');
+            // We had to remove `->nullable()` from this column in this migration in order to allow future alterations to this column. It would allow this to be set initially but when making futer changes gives error of "Invalid default value."
+            $table->tinyInteger('complete')->index()->after('gpa');
         });
     }
 

--- a/database/migrations/2014_10_02_135113_update-status-on-app.php
+++ b/database/migrations/2014_10_02_135113_update-status-on-app.php
@@ -15,8 +15,10 @@ class UpdateStatusOnApp extends Migration
             $table->dropIndex('applications_complete_index');
             $table->renameColumn('complete', 'submitted');
         });
+
         Schema::table('applications', function ($table) {
-            $table->tinyInteger('completed')->after('submitted')->nullable();
+            // We had to remove `->nullable()` from this column in this migration in order to allow future alterations to this column. It would allow this to be set initially but when making futer changes gives error of "Invalid default value."
+            $table->tinyInteger('completed')->after('submitted');
             $table->index('completed');
             $table->index('submitted');
         });


### PR DESCRIPTION
#### What's this PR do?

This includes a complete refactoring of the `wipe:applicants` command to hopefully address all the issues we've been seeing with it.

🔢 It now calls `delete()` instead of `truncate()` on the tables, which wipes all data from the tables while preserving the `auto_increment`. This update helps us to avoid conflicts and was also part of the issues we were seeing with admins. This change also allows us to avoid manually changing and SQL settings in code.

🚔 Use a new method to preserve admins. Previously we saved the admin users, wiped the database, and re-created the admin users. Without preserving the `auto_increment`, this also meant that the `user_id` column in the `role_user` table did not necessarily match with the new admin user `id`s. NOW we use a more specific query and only delete non-admins from the `users` table to begin with.

📢 The confirmation prompts have been updated to better reflect current practices.

🥞 Updates old migrations that were borked on new environments. These updates will not run on any existing non-local environments.

✍️ Adds logging about how many admins we have and who they are so that doesn't need to be manually checked in the database.

#### How should this be reviewed?
Will this wipe out all the application data from last year but keep admin users?

#### Any background context you want to provide?
I think it's all included above!

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/161970576)

#### Checklist
- [ ] Tested on Whitelabel.
