### PR TITLE
Update footer logo handling

### DIFF
--- a/resources/assets/sass/_regions/_footer.scss
+++ b/resources/assets/sass/_regions/_footer.scss
@@ -8,12 +8,9 @@
 [role="contentinfo"] { @include container(95%); color: #eee; padding: pxcalc(20) 0 pxcalc(50); text-align: center;
 
   .__partner {
-    span,
-    img { display: inline-block; }
-
     span { bottom: pxcalc(5); line-height: 1; margin: pxcalc(15) pxcalc(5) 0 0; vertical-align: top; }
 
-    img { max-height: 50px; max-width: 150px; }
+    img { max-height: 50px; max-width: 200px; }
   }
 
   .__copyright { padding-top: 1.5em; }


### PR DESCRIPTION
#### What's this PR do?
Remove the `inline-block` display from the partner logo area and increase the max-width.

#### How should this be reviewed?
Look at it carrreeeefuullllly

#### Any background context you want to provide?
The DSS Logo was too small and misaligned with the applied margin on the partner span. If we stack them we never have to worry about top margin and we can let the logo be a little bigger.

![screen shot 2019-02-11 at 11 58 33 am](https://user-images.githubusercontent.com/1865372/52579645-936a5400-2df4-11e9-97f8-298488e1c2aa.png)


