### PR TITLE
Use storage facade for images on "pages"

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -55,10 +55,17 @@ class PagesController extends \Controller
 
         $page = new Page();
         if (Input::hasFile('hero_image')) {
-            $file = Input::file('hero_image');
-            $filename = $file->getClientOriginalName();
-            $file->move(public_path().'/pages/images/', $filename);
-            $page->hero_image = '/pages/images'.$filename;
+            $file = file_get_contents(Input::file('hero_image')->getRealPath());
+
+            // Set title in the database
+            $filename = Input::file('hero_image')->getClientOriginalName();
+            $page->hero_image = '/pages/images/'.$filename;
+
+            // Save file to S3 (or local storage)
+            $extension = Input::file('hero_image')->guessExtension();
+            $storagePath = uploadedContentPath('pages/images').'/'.$filename.'.'.$extension;
+
+            Storage::put($storagePath, $file, 'public');
         }
         $page->title = $input['title'];
         if (! empty($input['description'])) {
@@ -203,10 +210,17 @@ class PagesController extends \Controller
 
         // @TODO: if image already exists, should we delete old one?
         if (Input::hasFile('hero_image')) {
-            $file = Input::file('hero_image');
-            $filename = $file->getClientOriginalName();
-            $file->move(public_path().'/pages/images/', $filename);
-            $inputText['hero_image'] = '/pages/images/'.$filename;
+            $file = file_get_contents(Input::file('hero_image')->getRealPath());
+
+            // Set title in the database
+            $filename = Input::file('hero_image')->getClientOriginalName();
+            $page->hero_image = '/pages/images/'.$filename;
+
+            // Save file to S3 (or local storage)
+            $extension = Input::file('hero_image')->guessExtension();
+            $storagePath = uploadedContentPath('pages/images').'/'.$filename.'.'.$extension;
+
+            Storage::put($storagePath, $file, 'public');
         }
 
         $inputText['description_html'] = MarkdownExtra::defaultTransform($inputText['description']);


### PR DESCRIPTION
#### What's this PR do?

🖼 When saving images on Pages, we weren't using the `Storage` facade but on the front end we pull from `Storage`. So, the frontend looks in S3 and does not find the image there. I've tried to update the `page` model to store in S3 and from what I can tell it works locally, but locally I'm not able to actually store on S3 so I can't be sure.

#### How should this be reviewed?

Will this work when connected to S3?

#### Any background context you want to provide?

Issues noticed on Footlocker Internal!

#### Relevant tickets
🤠 

#### Checklist
- [ ] Tested on Whitelabel.
