### PR TITLE
Upload winner images to S3, if using that driver.

### DIFF
--- a/app/Http/Controllers/WinnerController.php
+++ b/app/Http/Controllers/WinnerController.php
@@ -76,8 +76,10 @@ class WinnerController extends \Controller
         $image = $request->file('photo');
         if ($request->hasFile('photo')) {
             $filename = time().'-'.stringtoKebabCase($image->getClientOriginalName());
-            $image->move(uploadedContentPath('images').'/winners/', $filename);
-            $winner->photo = '/content/images/winners/'.$filename;
+            $storagePath = uploadedContentPath('images/winners').'/'.$filename;
+
+            Storage::put($storagePath, $file, 'public');
+            $winner->photo = $storagePath;
         }
 
         $winner->save();


### PR DESCRIPTION
#### What's this PR do?
This pull request uses `Storage::put` to upload images of winners, rather than explicitly "moving" the file on the disk. This allows us to use S3 to host this image on production.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Unblocks an issue with Footlocker's external scholarship.

#### Relevant tickets
Fixes https://github.com/DoSomething/longshot/issues/937

#### Checklist
- [ ] Tested on Whitelabel.